### PR TITLE
fix: replaced external-dns annotation with label

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 0.5.3
+version: 0.5.4

--- a/charts/simple-deployment/templates/ingress.yaml
+++ b/charts/simple-deployment/templates/ingress.yaml
@@ -8,7 +8,7 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}
   {{- with .Values.ingress }}
-  {{- if or .annotations .wwwRedirect .createDNSRecord }}
+  {{- if or .annotations .wwwRedirect }}
   annotations:
     {{- with.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -16,14 +16,14 @@ metadata:
     {{- if and .wwwRedirect (eq .ingressClassName "nginx") }}
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
-    {{- if .createDNSRecord }}
-    external-dns.alpha.kubernetes.io/hostname: {{ .host }}
-    {{- end }}
   {{- end }}
   labels:
     {{- include "deployment.labels" $ | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .createDNSRecord }}
+    external-dns-create: "true"
     {{- end }}
   {{- end }}
 spec:


### PR DESCRIPTION
External DNS now does label filtering. The `external-dns.alpha.kubernetes.io/hostname` annotation is now replaced with `external-dns-create` label instead. 
No change needed to upgrade.