### PR TITLE
feat: DevX images versions defaults to Chart.yaml appVersion

### DIFF
--- a/charts/devx-dashboard/Chart.yaml
+++ b/charts/devx-dashboard/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v2
 name: devx-dashboard
 description: A developer dashboard for releasing software
-version: 1.0.1
+version: 1.1.1
+appVersion: 1.0.4
 dependencies:
 - name: iam-service-account
   version: 1.1.4

--- a/charts/devx-dashboard/templates/_helpers.tpl
+++ b/charts/devx-dashboard/templates/_helpers.tpl
@@ -20,7 +20,7 @@ ad.datadoghq.com/{{ include "devx.name" $ }}.logs: '[{"source": "{{ include "dev
 {{- define "devx.dataDogLabels" -}}
 {{- if $.Values.dataDog.enableLogs -}}
 tags.datadoghq.com/service: {{ include "devx.name" $ }}
-tags.datadoghq.com/version: {{ .Chart.Version }}
+tags.datadoghq.com/version: {{ .Chart.AppVersion }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/devx-dashboard/templates/backend-dead-letter-deployment.yaml
+++ b/charts/devx-dashboard/templates/backend-dead-letter-deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: "{{ .container.image }}:{{ .container.tag }}"
+        image: "{{ .container.image }}:{{ .container.tag | default $.Chart.AppVersion }}"
         resources:
           limits:
             cpu: 600m

--- a/charts/devx-dashboard/templates/backend-release-board-deployment.yaml
+++ b/charts/devx-dashboard/templates/backend-release-board-deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: "{{ .container.image }}:{{ .container.tag }}"
+        image: "{{ .container.image }}:{{ .container.tag | default $.Chart.AppVersion }}"
         resources:
           limits:
             cpu: 600m

--- a/charts/devx-dashboard/templates/frontend-deployment.yaml
+++ b/charts/devx-dashboard/templates/frontend-deployment.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: portal
-        image: "{{ .container.image }}:{{ .container.tag }}"
+        image: "{{ .container.image }}:{{ .container.tag | default $.Chart.AppVersion }}"
         resources:
           limits:
             cpu: 600m

--- a/charts/devx-dashboard/values.yaml
+++ b/charts/devx-dashboard/values.yaml
@@ -57,7 +57,8 @@ frontend:
 
     container:
       image: europe-west3-docker.pkg.dev/tinkerbell-329710/ok-shared-registry/devx/ok.devx.dashboard.portal
-      tag: 1.0.4  #Dont use latest
+      # Uncomment tag if you want to set a specific version
+      # tag: 1.0.4
 
       # Environment variables
       environment: {}
@@ -98,7 +99,9 @@ releaseBoard:
 
     container:
       image: europe-west3-docker.pkg.dev/tinkerbell-329710/ok-shared-registry/devx/ok.devx.dashboard.modules.releaseboard
-      tag: 1.0.4
+      # Uncomment tag if you want to set a specific version
+      # tag: 1.0.4
+
       environment: {}
 
   service:
@@ -113,7 +116,7 @@ releaseBoard:
     project: <project-name>
     # The UUID of the Azure Boards Query to get data from.
     boardsQueryId: <uuid>
-  
+
   # Below lists are lists of pipelines that you want to able to start.
   # The requirements are a repository name and a pipeline ID.
   pipelines:
@@ -138,9 +141,11 @@ deadLetter:
     podAnnotations: {}
 
     replicas: 1
-    container: 
+    container:
       image: europe-west3-docker.pkg.dev/tinkerbell-329710/ok-shared-registry/devx/ok.devx.dashboard.modules.deadletter
-      tag: 1.0.4
+      # Uncomment tag if you want to set a specific version
+      # tag: 1.0.4
+
       environment: {}
 
   service:
@@ -152,7 +157,7 @@ deadLetter:
     # - PubSubSubscriptionName: deadletter-subscription-name
     #   CredentialsPath: /secret/another-secret
     #   ProjectId: another-gcp
-    
+
 # Configuration of service account - Not required if dead letter is disabled
 iamServiceAccount:
   name: <example-service-devx>


### PR DESCRIPTION
Image tags on portal, release and deadletter modules are now defaulted to `appVersion` in `Chart.yaml`.
You can override the tag in each module in the `values.yaml` file.
