### PR TITLE
release: simple-deployment 1.0.0

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 1.0.0-rc3
+version: 1.0.0

--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 1.0.0-rc2
+version: 1.0.0-rc3

--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 0.6.5
+version: 1.0.0-rc1

--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 1.0.0-rc1
+version: 1.0.0-rc2

--- a/charts/simple-deployment/README.md
+++ b/charts/simple-deployment/README.md
@@ -4,8 +4,8 @@ This Helm chart is a very simple application deployment including an ingress and
 
 Here's a few bullet points on what it's capable of.
 - Configuring a deployment with a "main" container (your application).
-- Enabling a Google Cloud SQL Proxy sidecar in the pod.
-- Mounting secrets, configmaps or additional volumes into the pod.
+- Enabling a Google Cloud SQL Proxy sidecar in the pod with support for Workload Identity.
+- Mounting secrets, configmaps or additional volumes into the pods.
 - Enabling a service for the deployment.
 - Enabling an ingress with TLS.
 
@@ -26,8 +26,14 @@ deployment:
 Below example enables the Google Cloud SQL Proxy sidecar in the pod.
 
 ```yaml
+global:
+  # The Google Project ID.
+  # [Required for Cloud SQL Proxy]
+  projectID: my-google-project-id
+
 deployment:
   replicas: 1
+  serviceAccountName: my-service-account
   container:
     image: my-image
     tag: v0.1.5
@@ -36,16 +42,16 @@ deployment:
 
   cloudSQLProxy:
     enable: true
-    imageTag: 1.30.0
-    projectId: google-project-id
-    region: europe-west3
     instanceName: sqlinstance-name
-    secretKeyName: google-service-account-key
+
+    # If you are not using Workload Identity, set below field to use a credentials file instead.
+    # secretKeyName: my-service-account-key
 ```
 
 ## Examples 3
 
-Below example enables a service and an ingress definition with the deployment. By default the ingress configuration will create a standard path rule. All traffic with a PathPrefix of "/" will be routed to the service. You can add more path rules with the `addtionalPaths` property. A TLS configuration will also be created.
+Below example enables a service and an ingress definition with the deployment. By default the ingress configuration will create a standard path rule. All traffic with a PathPrefix of "/" will be routed to the service.
+You can add more path rules with the `addtionalPaths` property. A TLS configuration will also be created.
 
 ```yaml
 deployment:
@@ -60,17 +66,20 @@ service:
 
 ingress:
   enable: true
-  annotations:
-    cert-manager.io/cluster-issuer: nginx-http01
-  ingressClassName: nginx
   host: example.org
 ```
 
 # Example 4
 
 ```yaml
+global:
+  # The Google Project ID.
+  # [Required for Cloud SQL Proxy]
+  projectID: my-google-project-id
+
 deployment:
   replicas: 1
+  serviceAccountName: my-service-account
   container:
     image: my-image
     tag: v0.1.5
@@ -96,20 +105,13 @@ deployment:
 
   cloudSQLProxy:
     enable: true
-    imageTag: 1.30.0
-    projectId: google-project-id
-    region: europe-west3
     instanceName: sqlinstance-name
-    secretKeyName: google-service-account-key
 
 service:
   enable: true
 
 ingress:
   enable: true
-  annotations:
-    cert-manager.io/cluster-issuer: nginx-http01
-  ingressClassName: nginx
   host: example.org
   addtionalPaths:
   - path: /api/

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -11,38 +11,17 @@ chart-version: {{ .Chart.Version | quote }}
 {{- end -}}
 {{- end -}}
 
-{{- define "deployment.dataDogEnvs" -}}
-- name: CORECLR_ENABLE_PROFILING
-  value: "1"
-- name: CORECLR_PROFILER
-  value: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-- name: CORECLR_PROFILER_PATH
-  value: /app/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so
-- name: DD_PROFILING_ENABLED
-  value: "1"
-- name: DD_DOTNET_TRACER_HOME
-  value: /app/datadog
-- name: DD_TRACE_AGENT_URL
-  value: unix:///var/run/datadog/apm.socket
-- name: DD_LOGS_INJECTION
-  value: 'true'
-- name: DD_SERVICE
-  value: {{ include "deployment.name" $ }}
-- name: DD_VERSION
-  value: {{ .Values.deployment.container.tag }}
-- name: DD_AGENT_HOST
-  valueFrom:
-    fieldRef:
-      fieldPath: status.hostIP
-{{- end -}}
-
 {{- define "deployment.dataDogAnnotations" -}}
+{{- if .Values.deployment.dataDog.enableLogs }}
 ad.datadoghq.com/{{ include "deployment.name" $ }}.logs: '[{"source": "{{ include "deployment.name" $ }}", "service": "{{ include "deployment.name" $ }}"}]'
+{{- end -}}
 {{- end -}}
 
 {{- define "deployment.dataDogLabels" -}}
+{{- if .Values.deployment.dataDog.enableLogs }}
 tags.datadoghq.com/service: {{ include "deployment.name" $ | quote }}
 tags.datadoghq.com/version: {{ .Values.deployment.container.tag | quote }}
+{{- end -}}
 {{- end -}}
 
 {{- define "deployment.livenessProbe" -}}

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -87,13 +87,17 @@ failureThreshold: {{ .readinessProbe.failureThreshold }}
   command:
     - "/cloud-sql-proxy"
     - "{{ $projectID }}:{{ .cloudSQLProxy.region | default "europe-west3" }}:{{ .cloudSQLProxy.instanceName }}"
-    - "--credentials-file=/secrets/{{ .cloudSQLProxy.secretKeyName }}/key.json"
     - "--auto-iam-authn"
+    {{- if .cloudSQLProxy.secretKeyName }}
+    - "--credentials-file=/secrets/{{ .cloudSQLProxy.secretKeyName }}/key.json"
+    {{- end }}
   securityContext:
     runAsNonRoot: true
+  {{- if .cloudSQLProxy.secretKeyName }}
   volumeMounts:
     - name: {{ .cloudSQLProxy.secretKeyName }}
       mountPath: "/secrets/{{ .cloudSQLProxy.secretKeyName }}"
       readOnly: true
+  {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -48,6 +48,7 @@ failureThreshold: {{ .readinessProbe.failureThreshold | default 3 }}
 
 {{- define "deployment.cloudSQLProxy" -}}
 {{- with .Values.deployment -}}
+{{- if .cloudSQLProxy.enable }}
 
 {{- /* Below if statments makes sure that you cannot specify to use version 1 of Cloud SQL Proxy */ -}}
 {{- if .cloudSQLProxy.imageTag -}}
@@ -78,5 +79,6 @@ failureThreshold: {{ .readinessProbe.failureThreshold | default 3 }}
       mountPath: "/secrets/{{ .cloudSQLProxy.secretKeyName }}"
       readOnly: true
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -86,7 +86,7 @@ failureThreshold: {{ .readinessProbe.failureThreshold }}
   image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .cloudSQLProxy.imageTag | default "2.3.0" }}"
   command:
     - "/cloud-sql-proxy"
-    - "{{ $projectID }}:{{ .cloudSQLProxy.region }}:{{ .cloudSQLProxy.instanceName }}"
+    - "{{ $projectID }}:{{ .cloudSQLProxy.region | default "europe-west3" }}:{{ .cloudSQLProxy.instanceName }}"
     - "--credentials-file=/secrets/{{ .cloudSQLProxy.secretKeyName }}/key.json"
     - "--auto-iam-authn"
   securityContext:

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -49,22 +49,22 @@ tags.datadoghq.com/version: {{ .Values.deployment.container.tag | quote }}
 httpGet:
   path: {{ .livenessProbe.httpGet.path }}
   port: {{ .containerPort }}
-initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds }}
-periodSeconds: {{ .livenessProbe.periodSeconds }}
-timeoutSeconds: {{ .livenessProbe.timeoutSeconds }}
-successThreshold: 1
-failureThreshold: {{ .livenessProbe.failureThreshold }}
+initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds | default 5 }}
+periodSeconds: {{ .livenessProbe.periodSeconds | default 10}}
+timeoutSeconds: {{ .livenessProbe.timeoutSeconds | default 1 }}
+successThreshold: {{ .livenessProbe.failureThreshold | default 1 }}
+failureThreshold: {{ .livenessProbe.failureThreshold | default 3 }}
 {{- end -}}
 
 {{- define "deployment.readinessProbe" -}}
 httpGet:
   path: {{ .readinessProbe.httpGet.path }}
   port: {{ .containerPort }}
-initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds }}
-periodSeconds: {{ .readinessProbe.periodSeconds }}
-timeoutSeconds: {{ .readinessProbe.timeoutSeconds }}
-successThreshold: {{ .readinessProbe.successThreshold }}
-failureThreshold: {{ .readinessProbe.failureThreshold }}
+initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds | default 5 }}
+periodSeconds: {{ .readinessProbe.periodSeconds | default 10}}
+timeoutSeconds: {{ .readinessProbe.timeoutSeconds | default 1 }}
+successThreshold: {{ .readinessProbe.failureThreshold | default 1 }}
+failureThreshold: {{ .readinessProbe.failureThreshold | default 3 }}
 {{- end -}}
 
 {{- define "deployment.cloudSQLProxy" -}}

--- a/charts/simple-deployment/templates/deployment.yaml
+++ b/charts/simple-deployment/templates/deployment.yaml
@@ -119,7 +119,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if .Values.deployment.cloudSQLProxy.enable }}
-      {{- include "deployment.cloudSQLProxy" .Values.deployment | nindent 6 }}
+      {{- include "deployment.cloudSQLProxy" $ | nindent 6 }}
       {{- end }}
       {{- with .Values.deployment }}
       {{- if or .cloudSQLProxy.enable .container.secrets .container.configMaps .additionalVolumes .dataDog.enableTracing }}

--- a/charts/simple-deployment/templates/deployment.yaml
+++ b/charts/simple-deployment/templates/deployment.yaml
@@ -122,9 +122,9 @@ spec:
       {{- include "deployment.cloudSQLProxy" $ | nindent 6 }}
       {{- end }}
       {{- with .Values.deployment }}
-      {{- if or .cloudSQLProxy.enable .container.secrets .container.configMaps .additionalVolumes .dataDog.enableTracing }}
+      {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.configMaps .additionalVolumes .dataDog.enableTracing }}
       volumes:
-        {{- if .cloudSQLProxy.enable }}
+        {{- if and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName }}
         - name: {{ .cloudSQLProxy.secretKeyName }}
           secret:
             secretName: {{ .cloudSQLProxy.secretKeyName }}

--- a/charts/simple-deployment/templates/deployment.yaml
+++ b/charts/simple-deployment/templates/deployment.yaml
@@ -1,9 +1,4 @@
-{{- $logsEnabled := false }}
-{{- if .Values.deployment.dataDog.enableTracing }}
-{{- $logsEnabled = true }}
-{{- else }}
-{{- $logsEnabled = .Values.deployment.dataDog.enableLogs }}
-{{- end }}
+{{- $logsEnabled := .Values.deployment.dataDog.enableLogs }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -26,22 +21,18 @@ spec:
   revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit | default 5 }}
   template:
     metadata:
-    {{- if or .Values.deployment.podAnnotations $logsEnabled }}
+      {{- if or .Values.deployment.podAnnotations .Values.deployment.dataDog.enableLogs }}
       annotations:
+        {{- include "deployment.dataDogAnnotations" $ | nindent 8 }}
         {{- with .Values.deployment.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- if $logsEnabled }}
-        {{- include "deployment.dataDogAnnotations" $ | nindent 8 }}
         {{- end }}
       {{- end }}
       labels:
         {{- include "deployment.labels" . | nindent 8 }}
+        {{- include "deployment.dataDogLabels" $ | nindent 8 }}
         {{- range $k, $v := .Values.deployment.podLabels }}
         {{- printf "%s: %s" $k ($v | quote) | nindent 8 }}
-        {{- end }}
-        {{- if $logsEnabled }}
-        {{- include "deployment.dataDogLabels" $ | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.deployment.serviceAccountName }}
@@ -93,11 +84,8 @@ spec:
               fieldRef:
                 fieldPath: {{ $value }}
           {{- end }}
-          {{- if $.Values.deployment.dataDog.enableTracing }}
-          {{- include "deployment.dataDogEnvs" $ | nindent 10 }}
-          {{- end }}
         {{- end }}
-        {{- if or .secrets .configMaps .additionalVolumeMounts $.Values.deployment.dataDog.enableTracing }}
+        {{- if or .secrets .configMaps .additionalVolumeMounts }}
         volumeMounts:
           {{- range $secret := .secrets }}
           - name: {{ $secret }}
@@ -112,17 +100,13 @@ spec:
           - name: {{ $volumeMount.name }}
             mountPath: {{ $volumeMount.mountPath }}
           {{- end }}
-          {{- if $.Values.deployment.dataDog.enableTracing }}
-          - name: apmsocketpath
-            mountPath: /var/run/datadog
-          {{- end }}
         {{- end }}
       {{- end }}
       {{- if .Values.deployment.cloudSQLProxy.enable }}
       {{- include "deployment.cloudSQLProxy" $ | nindent 6 }}
       {{- end }}
       {{- with .Values.deployment }}
-      {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.configMaps .additionalVolumes .dataDog.enableTracing }}
+      {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.configMaps .additionalVolumes }}
       volumes:
         {{- if and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName }}
         - name: {{ .cloudSQLProxy.secretKeyName }}
@@ -146,11 +130,6 @@ spec:
         {{- end }}
         {{- with .additionalVolumes }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- if .dataDog.enableTracing }}
-        - hostPath:
-            path: /var/run/datadog
-          name: apmsocketpath
         {{- end }}
       {{- end }}
       {{- end }}

--- a/charts/simple-deployment/templates/deployment.yaml
+++ b/charts/simple-deployment/templates/deployment.yaml
@@ -51,7 +51,9 @@ spec:
         args: {{ .args | toJson }}
         {{- end }}
         {{- end }}
-
+        securityContext:
+          allowPrivilegeEscalation: {{ .allowPrivilegeEscalation | default "false" }}
+          privileged: {{ .privileged | default "false" }}
         {{- with .resources }}
         resources:
         {{- toYaml . | nindent 10 }}

--- a/charts/simple-deployment/templates/deployment.yaml
+++ b/charts/simple-deployment/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     matchLabels:
       app: {{ include "deployment.name" $ }}
   replicas: {{ .Values.deployment.replicas }}
-  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit | default 5 }}
   template:
     metadata:
     {{- if or .Values.deployment.podAnnotations $logsEnabled }}

--- a/charts/simple-deployment/templates/deployment.yaml
+++ b/charts/simple-deployment/templates/deployment.yaml
@@ -1,5 +1,3 @@
-{{- $logsEnabled := .Values.deployment.dataDog.enableLogs }}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,9 +33,7 @@ spec:
         {{- printf "%s: %s" $k ($v | quote) | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.deployment.serviceAccountName }}
-      serviceAccountName: {{ .Values.deployment.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ .Values.deployment.serviceAccountName | default "default" }}
       {{- with .Values.deployment.imagePullSecrets }}
       imagePullSecrets:
       {{- range $secret := . }}
@@ -102,9 +98,7 @@ spec:
           {{- end }}
         {{- end }}
       {{- end }}
-      {{- if .Values.deployment.cloudSQLProxy.enable }}
       {{- include "deployment.cloudSQLProxy" $ | nindent 6 }}
-      {{- end }}
       {{- with .Values.deployment }}
       {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.configMaps .additionalVolumes }}
       volumes:

--- a/charts/simple-deployment/templates/ingress.yaml
+++ b/charts/simple-deployment/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- if .wwwRedirect }}
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
-    nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | quote }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
     cert-manager.io/cluster-issuer: nginx-http01
   labels:
     {{- include "deployment.labels" $ | nindent 4 }}

--- a/charts/simple-deployment/templates/ingress.yaml
+++ b/charts/simple-deployment/templates/ingress.yaml
@@ -8,15 +8,15 @@ kind: Ingress
 metadata:
   name: {{ include "deployment.name" $ }}
   {{- with .Values.ingress }}
-  {{- if or .annotations .wwwRedirect }}
   annotations:
-    {{- with.annotations }}
+    {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if and .wwwRedirect (eq .ingressClassName "nginx") }}
+    {{- if .wwwRedirect }}
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
-  {{- end }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | quote }}
+    cert-manager.io/cluster-issuer: nginx-http01
   labels:
     {{- include "deployment.labels" $ | nindent 4 }}
     {{- range $k, $v := .labels }}
@@ -27,7 +27,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | default "nginx" }}
   rules:
   - host: {{ .Values.ingress.host }}
     http:

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -26,11 +26,6 @@ deployment:
     # If in doubt, ask a collauge or the infrastructure team.
     enableLogs: false
 
-    # Enable DataDog tracing with correlated logs. You will need this Nuget package for .NET Core, https://www.nuget.org/packages/Datadog.Monitoring.Distribution
-    # Enabling tracing will override and enable the above DataDog logs.
-    # Make sure your logs comply with the okamba standard ruleset.
-    enableTracing: false
-
   # Pod Replicas
   replicas: 1
 

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -34,8 +34,6 @@ deployment:
   # Pod Replicas
   replicas: 1
 
-  # Replicaset revision history limit.
-  revisionHistoryLimit: 5
 
   # Pod Annotations
   podAnnotations: {}

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -119,9 +119,11 @@ deployment:
   # Find the latest version here, https://gcr.io/cloudsql-docker/gce-proxy
   cloudSQLProxy:
     enable: false
-    region: europe-west3
     instanceName: sqlinstance-name
     secretKeyName: google-service-account-key
+
+    # Immutable, if not specified, region will default to europe-west3
+    # region: europe-west3
 
 ##################################################
 #                    Service                     #

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -112,15 +112,21 @@ deployment:
   # - name: cache-volume
   #   emptyDir: {}
 
-  # Assign a Kubernetes service account.
-  # serviceAccountName: default
+  # Assign a service account for your application.
+  # This service account represents your application and is used for authentication
+  # with Workload Identity. The service account must be Workload Identity enabled.
+  serviceAccountName: default
 
   # Enable the Google Cloud SQL Proxy sidecar
-  # Find the latest version here, https://gcr.io/cloudsql-docker/gce-proxy
+  # Find the latest version here, https://gcr.io/cloud-sql-connectors/cloud-sql-proxy
   cloudSQLProxy:
     enable: false
     instanceName: sqlinstance-name
-    secretKeyName: google-service-account-key
+
+    # [Deprecated]
+    # If specified, Cloud SQL Proxy will use the provided credentials file for authn
+    # insted of application default login aka Workload Identity.
+    # secretKeyName: google-service-account-key
 
     # Immutable, if not specified, region will default to europe-west3
     # region: europe-west3

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -2,6 +2,10 @@ global:
   # Add labels from a parent chart to all manifests.
   labels: {}
 
+  # The Google Project ID.
+  # [Required for Cloud SQL Proxy]
+  projectID: null
+
 # Will rename all resources.
 fullnameOverride: ""
 
@@ -115,7 +119,6 @@ deployment:
   # Find the latest version here, https://gcr.io/cloudsql-docker/gce-proxy
   cloudSQLProxy:
     enable: false
-    projectId: google-project-id
     region: europe-west3
     instanceName: sqlinstance-name
     secretKeyName: google-service-account-key

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -115,7 +115,6 @@ deployment:
   # Find the latest version here, https://gcr.io/cloudsql-docker/gce-proxy
   cloudSQLProxy:
     enable: false
-    imageTag: 1.31.0
     projectId: google-project-id
     region: europe-west3
     instanceName: sqlinstance-name

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -34,14 +34,13 @@ deployment:
   # Pod Replicas
   replicas: 1
 
-
   # Pod Annotations
   podAnnotations: {}
 
   # Pod Labels
   podLabels: {}
 
-  # Array of imagePullSecret's
+  # Used for Image Registry credentials other than your default registry.
   imagePullSecrets: []
     #- secret-name-here
 
@@ -142,22 +141,22 @@ ingress:
   # Enable the ingress definition.
   enable: false
 
+  # Labels on the Ingress definition.
+  labels: {}
+
+  # Annotations on the Ingress definition.
+  annotations: {}
+
+  # URL of the application
+  host: example.org
+
   # Creating DNS records is only supported in our test environment.
   # If needed, only enable this setting on the specific enrionment value file.
   createDNSRecord: false
 
-  # Annotations on the Ingress definition.
-  annotations:
-    cert-manager.io/cluster-issuer: nginx-http01
-
-  # Labels on the Ingress definition.
-  labels: {}
-
-  # Ingress Class
-  ingressClassName: nginx
-
-  # URL of the application
-  host: example.org
+  # Redirect HTTP to HTTPS.
+  # SSL Redirect is disabled for security reasons. Enable only for frontend applications.
+  sslRedirect: false
 
   # Redirect www.example.org to example.org.
   # Use this for custmer facing sites to support old Boomer habits.

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -69,20 +69,11 @@ deployment:
       enable: true
       httpGet:
         path: /healthz
-      initialDelaySeconds: 5
-      periodSeconds: 10
-      timeoutSeconds: 1
-      failureThreshold: 3
 
     readinessProbe:
       enable: true
       httpGet:
         path: /readyz
-      initialDelaySeconds: 5
-      periodSeconds: 10
-      timeoutSeconds: 1
-      successThreshold: 1
-      failureThreshold: 3
 
     environment: {}
       # SOME_ENV: some-value


### PR DESCRIPTION
## Features include
- Cloud SQL Proxy
  - Updated to major version 2.
  - Supports Workload Identity.
  - `region` and `imageTag` are now hidden defaults
  - `projectId` field is moved to `global` block and renamed to `projectID`. 
 - Opt-in SSL rules on ingress configuration
 - Rarely used fields in `values.yaml` are now hidden defaults.
 - DataDog tracing configuration support removed.
 - Default secrityContext added on main container.

## Breaking Changes
- If the `deployment.cloudSQLProxy.imageTag` major version is less than 2, the chart will not template.
- SSL Redirection is disabled by default on the ingress. You must explicitly enable it on the ingress configuration.
