### PR TITLE
New chart: Kubernetes Cronjob

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cronjob
 description: Kubernetes CronJob Resource
-version: 0.1.0-rc5
+version: 0.1.0
 

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cronjob
 description: Kubernetes CronJob Resource
-version: 0.1.0-rc3
+version: 0.1.0-rc4
 

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: cronjob
+description: Kubernetes CronJob Resource
+version: 0.0.1
+

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cronjob
 description: Kubernetes CronJob Resource
-version: 0.1.0-rc1
+version: 0.1.0-rc2
 

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cronjob
 description: Kubernetes CronJob Resource
-version: 0.1.0-rc4
+version: 0.1.0-rc5
 

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cronjob
 description: Kubernetes CronJob Resource
-version: 0.0.1
+version: 0.1.0-rc1
 

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cronjob
 description: Kubernetes CronJob Resource
-version: 0.1.0-rc2
+version: 0.1.0-rc3
 

--- a/charts/cronjob/templates/_helper.tpl
+++ b/charts/cronjob/templates/_helper.tpl
@@ -1,0 +1,38 @@
+{{- define "cronjob.labels" -}}
+app: {{ .Release.Name | quote }}
+chart-name: {{ .Chart.Name | quote }}
+chart-version: {{ .Chart.Version | quote }}
+{{- range $k, $v := .Values.global.labels }}
+{{ printf "%s: %s" $k ($v | quote) }}
+{{- end -}}
+{{- end -}}
+
+{{- define "deployment.dataDogAnnotations" -}}
+ad.datadoghq.com/{{ .Values.name }}.logs: '[{"source": "{{ .Values.name }}", "service": "{{ .Values.name }}"}]'
+{{- end -}}
+
+{{- define "cronjob.cloudSQLProxy" -}}
+{{- if not .Values.global.projectID }}
+{{- fail "The global.projectID is not set. It is required for Cloud SQL Proxy." -}}
+{{- end -}}
+
+{{- with .Values.job -}}
+- name: cloud-sql-proxy
+  image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .cloudSQLProxy.imageTag | default "2.3.0" }}"
+  command:
+    - "/cloud-sql-proxy"
+    - "{{ $.Values.global.projectID }}:{{ .cloudSQLProxy.region | default "europe-west3" }}:{{ .cloudSQLProxy.instanceName }}"
+    - "--auto-iam-authn"
+    {{- if .cloudSQLProxy.secretKeyName }}
+    - "--credentials-file=/secrets/{{ .cloudSQLProxy.secretKeyName }}/key.json"
+    {{- end }}
+  securityContext:
+    runAsNonRoot: true
+  {{- if .cloudSQLProxy.secretKeyName }}
+  volumeMounts:
+    - name: {{ .cloudSQLProxy.secretKeyName }}
+      mountPath: "/secrets/{{ .cloudSQLProxy.secretKeyName }}"
+      readOnly: true
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/cronjob/templates/_helper.tpl
+++ b/charts/cronjob/templates/_helper.tpl
@@ -18,11 +18,13 @@ ad.datadoghq.com/{{ .Values.name }}.logs: '[{"source": "{{ .Values.name }}", "se
 
 {{- with .Values.job -}}
 - name: cloud-sql-proxy
-  image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .cloudSQLProxy.imageTag | default "2.3.0" }}"
+  image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .cloudSQLProxy.imageTag | default "2.4.0" }}"
   command:
     - "/cloud-sql-proxy"
     - "{{ $.Values.global.projectID }}:{{ .cloudSQLProxy.region | default "europe-west3" }}:{{ .cloudSQLProxy.instanceName }}"
     - "--auto-iam-authn"
+    - "--structured-logs"
+    - "--quitquitquit"
     {{- if .cloudSQLProxy.secretKeyName }}
     - "--credentials-file=/secrets/{{ .cloudSQLProxy.secretKeyName }}/key.json"
     {{- end }}

--- a/charts/cronjob/templates/_helper.tpl
+++ b/charts/cronjob/templates/_helper.tpl
@@ -7,7 +7,7 @@ chart-version: {{ .Chart.Version | quote }}
 {{- end -}}
 {{- end -}}
 
-{{- define "deployment.dataDogAnnotations" -}}
+{{- define "cronjob.dataDogAnnotations" -}}
 ad.datadoghq.com/{{ .Values.name }}.logs: '[{"source": "{{ .Values.name }}", "service": "{{ .Values.name }}"}]'
 {{- end -}}
 

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -72,6 +72,7 @@ spec:
             resources:
             {{- toYaml . | nindent 14 }}
             {{- end }}
+
             {{- if or .environment .fieldRefEnvironment }}
             env:
               {{- range $name, $value := .environment }}
@@ -85,6 +86,7 @@ spec:
                     fieldPath: {{ $value }}
               {{- end }}
             {{- end }}
+
             {{- if or .secrets .configMaps }}
             volumeMounts:
               {{- range $secret := .secrets }}
@@ -97,32 +99,32 @@ spec:
                 mountPath: {{ $configMap.mountPath }}
               {{- end }}
             {{- end }}
-        {{- end }}
-
-        {{- if .cloudSQLProxy.enable }}
-        {{- include "cronjob.cloudSQLProxy" $ | nindent 10 }}
-        {{- end }}
-        {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.configMaps }}
-        volumes:
-          {{- if and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName }}
-          - name: {{ .cloudSQLProxy.secretKeyName }}
-            secret:
-              secretName: {{ .cloudSQLProxy.secretKeyName }}
           {{- end }}
 
-          {{- with .container }}
-          {{- range $secret := .secrets }}
-          {{- if not (and $.Values.job.cloudSQLProxy.enable (eq $.Values.job.cloudSQLProxy.secretKeyName $secret))}}
-          - name: {{ $secret }}
-            secret:
-              secretName: {{ $secret }}
+          {{- if .cloudSQLProxy.enable }}
+          {{- include "cronjob.cloudSQLProxy" $ | nindent 10 }}
           {{- end }}
+          {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.configMaps }}
+          volumes:
+            {{- if and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName }}
+            - name: {{ .cloudSQLProxy.secretKeyName }}
+              secret:
+                secretName: {{ .cloudSQLProxy.secretKeyName }}
+            {{- end }}
+
+            {{- with .container }}
+            {{- range $secret := .secrets }}
+            {{- if not (and $.Values.job.cloudSQLProxy.enable (eq $.Values.job.cloudSQLProxy.secretKeyName $secret))}}
+            - name: {{ $secret }}
+              secret:
+                secretName: {{ $secret }}
+            {{- end }}
+            {{- end }}
+            {{- range $configMap := .configMaps }}
+            - name: {{ $configMap.name }}
+              configMap:
+                name: {{ $configMap.name }}
+            {{- end }}
+            {{- end }}
           {{- end }}
-          {{- range $configMap := .configMaps }}
-          - name: {{ $configMap.name }}
-            configMap:
-              name: {{ $configMap.name }}
-          {{- end }}
-          {{- end }}
-        {{- end }}
     {{- end }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -63,9 +63,10 @@ spec:
 
             {{- if .command }}
             command: {{ .command | toJson }}
+            {{- end }}
+
             {{- if .args }}
             args: {{ .args | toJson }}
-            {{- end }}
             {{- end }}
 
             {{- with .resources }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -1,0 +1,128 @@
+{{ $types := list "Allow" "Forbid" "Replace" }}
+{{- if not (has .Values.concurrencyPolicy $types) }}
+{{- fail (printf "concurrencyPolicy [%s] does not have a valid type. Valid type: %s" .Values.concurrencyPolicy (join ", " $types)) }}
+{{- end }}
+
+{{ $types := list "Always" "OnFailure" "Never" }}
+{{- if not (has .Values.job.restartPolicy $types) }}
+{{- fail (printf "job.restartPolicy [%s] does not have a valid type. Valid type: %s" .Values.job.restartPolicy (join ", " $types)) }}
+{{- end }}
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.name }}
+  {{- with .Values.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "cronjob.labels" . | nindent 4 }}
+    {{- range $k, $v := .Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
+    {{- end }}
+spec:
+  schedule: {{ .Values.schedule }}
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  concurrencyPolicy: {{ .Values.concurrencyPolicy }}
+  {{- if .Values.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
+  {{- end }}
+  jobTemplate:
+    {{- with .Values.job }}
+    spec:
+      backoffLimit: {{ .backoffLimit | default 6 }}
+      {{- if .ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished }}
+      {{- end }}
+      template:
+        metadata:
+          {{- if .dataDog.enableLogs }}
+          annotations:
+            ad.datadoghq.com/{{ $.Values.name }}.logs: '[{"source": "{{ $.Values.name }}", "service": "{{ $.Values.name }}"}]'
+          labels:
+            tags.datadoghq.com/service: {{ $.Values.name | quote }}
+            tags.datadoghq.com/version: {{ .container.tag | quote }}
+          {{- end }}
+        spec:
+          {{- if .serviceAccountName }}
+          serviceAccountName: {{ .serviceAccountName }}
+          {{- end }}
+          {{- with .imagePullSecrets }}
+          imagePullSecrets:
+            {{- range $secret := . }}
+            - name: {{ $secret }}
+            {{- end }}
+          {{- end }}
+          restartPolicy: {{ .restartPolicy }}
+          containers:
+          {{- with .container }}
+          - name: {{ $.Values.name }}
+            image: "{{ .image }}:{{ .tag }}"
+
+            {{- if .command }}
+            command: {{ .command | toJson }}
+            {{- if .args }}
+            args: {{ .args | toJson }}
+            {{- end }}
+            {{- end }}
+
+            {{- with .resources }}
+            resources:
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- if or .environment .fieldRefEnvironment }}
+            env:
+              {{- range $name, $value := .environment }}
+              - name: {{ $name }}
+                value: {{ $value | quote }}
+              {{- end }}
+              {{- range $name, $value := .fieldRefEnvironment }}
+              - name: {{ $name }}
+                valueFrom:
+                  fieldRef:
+                    fieldPath: {{ $value }}
+              {{- end }}
+            {{- end }}
+            {{- if or .secrets .configMaps }}
+            volumeMounts:
+              {{- range $secret := .secrets }}
+              - name: {{ $secret }}
+                mountPath: /secrets/{{ $secret }}
+                readOnly: true
+              {{- end }}
+              {{- range $configMap := .configMaps }}
+              - name: {{ $configMap.name }}
+                mountPath: {{ $configMap.mountPath }}
+              {{- end }}
+            {{- end }}
+        {{- end }}
+
+        {{- if .cloudSQLProxy.enable }}
+        {{- include "cronjob.cloudSQLProxy" $ | nindent 10 }}
+        {{- end }}
+        {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.configMaps }}
+        volumes:
+          {{- if and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName }}
+          - name: {{ .cloudSQLProxy.secretKeyName }}
+            secret:
+              secretName: {{ .cloudSQLProxy.secretKeyName }}
+          {{- end }}
+
+          {{- with .container }}
+          {{- range $secret := .secrets }}
+          {{- if not (and $.Values.job.cloudSQLProxy.enable (eq $.Values.job.cloudSQLProxy.secretKeyName $secret))}}
+          - name: {{ $secret }}
+            secret:
+              secretName: {{ $secret }}
+          {{- end }}
+          {{- end }}
+          {{- range $configMap := .configMaps }}
+          - name: {{ $configMap.name }}
+            configMap:
+              name: {{ $configMap.name }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
+    {{- end }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
-  schedule: {{ .Values.schedule }}
+  schedule: {{ .Values.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
   concurrencyPolicy: {{ .Values.concurrencyPolicy }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -1,0 +1,110 @@
+global:
+  # Add labels from a parent chart to all manifests.
+  labels: {}
+  #
+  # The Google Project ID.
+  # [Required for Cloud SQL Proxy]
+  projectID: null
+
+##################################################
+#                   CronJob                      #
+##################################################
+
+name: cronjob-name
+
+# Labels on the CronJob definition.
+labels: {}
+
+# Annotations on the CronJob definition.
+annotations: {}
+
+# https://crontab.guru/ 
+schedule: "0 1 * * *"
+
+# Specify how many completed jobs should be kept. Kubernetes default value is 3.
+successfulJobsHistoryLimit: 3
+
+# Specify how many failed jobs should be kept. Kubernetes default value is 1.
+failedJobsHistoryLimit: 1
+
+# Optional, This field defines a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+startingDeadlineSeconds: null
+
+# Possible values Allow, Forbid, and Replace. Kubernetes default value is Allow.
+# Specifies how to treat concurrent executions of a job that is created by this CronJob.
+# https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy
+concurrencyPolicy: Allow
+
+# Main container configuration
+job:
+  dataDog:
+    # Enable DataDog logging. Please make sure that your logs comply with the okamba standard ruleset.
+    # If in doubt, ask a collauge or the infrastructure team.
+    enableLogs: false
+
+  # Specify the number of retries before considering a Job as failed. Kubernetes default value is 6.
+  # https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy
+  backoffLimit: 6
+
+  # Possible values Always, OnFailure, and Never. Kubernetes default value is Always.
+  # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+  restartPolicy: Always
+
+  # Optional, Clean up finished Jobs (either Complete or Failed) automatically is to use a TTL mechanism
+  # provided by a TTL controller for finished resources.
+  ttlSecondsAfterFinished: null
+  
+  # Assign a service account for your application.
+  # This service account represents your application and is used for authentication
+  # with Workload Identity. The service account must be Workload Identity enabled.
+  serviceAccountName: default
+
+  # Used for Image Registry credentials other than your default registry.
+  imagePullSecrets: []
+    # - secret-name-here
+
+  container:
+    image: example-image
+    tag: latest
+
+    # Enable custom command
+    #command: ["my-command"]
+    #args: ["with", "--params=yes"]
+
+    resources:
+      requests:
+        memory: 1000Mi
+        cpu: 400m
+      limits:
+        memory: 2000Mi
+        cpu: 1000m
+
+    environment: {}
+      # SOME_ENV: some-value
+
+    fieldRefEnvironment: {}
+      # SOME_ENV: some-field-reference
+
+    # Below list of kubernetes secret names will be mounted into the container
+    # under the path /secrets/<secret-name>/<secret-key>
+    secrets: []
+    # - very-secret
+
+    # Below list of configmaps will be mounted into he container.
+    configMaps: []
+    # - name: some-configmap
+    #   mountPath: /some/path
+
+  # Enable the Google Cloud SQL Proxy sidecar
+  # Find the latest version here, https://gcr.io/cloudsql-docker/gce-proxy
+  cloudSQLProxy:
+    enable: false
+    instanceName: sqlinstance-name
+
+    # [Deprecated]
+    # If specified, Cloud SQL Proxy will use the provided credentials file for authn
+    # insted of application default login aka Workload Identity.
+    # secretKeyName: google-service-account-key
+
+    # Immutable, if not specified, region will default to europe-west3
+    # region: europe-west3


### PR DESCRIPTION
A Kubernetes Cronjob chart with support for Cloud SQL Proxy. The Cloud SQL Proxy is started with the `--quitquitquit` parameter which enables a http endpoint on port 9091 only reachable from localhost. When the the job is finished just send a POST request to `http://localhost:9091/quitquitquit` to kill the process.