### PR TITLE
cronjob: changed default restartPolicy to Never

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cronjob
 description: Kubernetes CronJob Resource
-version: 0.1.0
+version: 0.1.1
 

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -3,7 +3,7 @@
 {{- fail (printf "concurrencyPolicy [%s] does not have a valid type. Valid type: %s" .Values.concurrencyPolicy (join ", " $types)) }}
 {{- end }}
 
-{{ $types := list "Always" "OnFailure" "Never" }}
+{{ $types := list "OnFailure" "Never" }}
 {{- if not (has .Values.job.restartPolicy $types) }}
 {{- fail (printf "job.restartPolicy [%s] does not have a valid type. Valid type: %s" .Values.job.restartPolicy (join ", " $types)) }}
 {{- end }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -46,9 +46,9 @@ job:
   # https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy
   backoffLimit: 6
 
-  # Possible values Always, OnFailure, and Never. Kubernetes default value is Always.
-  # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
-  restartPolicy: Always
+  # Possible values are OnFailure or Never.
+  # https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-template
+  restartPolicy: Never
 
   # Optional, Clean up finished Jobs (either Complete or Failed) automatically is to use a TTL mechanism
   # provided by a TTL controller for finished resources.


### PR DESCRIPTION
Changed the default values for `job.restartPolicy` to `Never`. The `Always` value is not supported for CronJobs.