### PR TITLE
cronjob: chart-name label is set to cronjob instead of .Chart.Name

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cronjob
 description: Kubernetes CronJob Resource
-version: 0.1.1
+version: 0.1.2
 

--- a/charts/cronjob/templates/_helper.tpl
+++ b/charts/cronjob/templates/_helper.tpl
@@ -1,6 +1,6 @@
 {{- define "cronjob.labels" -}}
 app: {{ .Release.Name | quote }}
-chart-name: {{ .Chart.Name | quote }}
+chart-name: cronjob
 chart-version: {{ .Chart.Version | quote }}
 {{- range $k, $v := .Values.global.labels }}
 {{ printf "%s: %s" $k ($v | quote) }}


### PR DESCRIPTION
The `chart-name` label is set to `cronjob` instead of `{{ .Chart.Name }}`. This is because the Chart name changes if you're using an alias on the dependency property.