### PR TITLE
db-migration: major version release v1.0.0

### DIFF
--- a/charts/db-migration/Chart.yaml
+++ b/charts/db-migration/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: db-migration
 description: A Helm chart for a running a DB migration.
-version: 0.2.1
+version: 1.0.0-rc1

--- a/charts/db-migration/Chart.yaml
+++ b/charts/db-migration/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: db-migration
 description: A Helm chart for a running a DB migration.
-version: 1.0.0-rc1
+version: 1.0.0

--- a/charts/db-migration/templates/_helpers.tpl
+++ b/charts/db-migration/templates/_helpers.tpl
@@ -14,3 +14,31 @@ chart-version: {{ .Chart.Version | quote }}
 {{ printf "%s: %s" $k ($v | quote) }}
 {{- end -}}
 {{- end -}}
+
+{{- define "db-migration.cloudSQLProxy" -}}
+{{- if not .Values.global.projectID }}
+{{- fail "The global.projectID is not set. It is required for Cloud SQL Proxy." -}}
+{{- end -}}
+
+{{- with .Values.job -}}
+- name: cloud-sql-proxy
+  image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .cloudSQLProxy.imageTag | default "2.4.0" }}"
+  command:
+    - "/cloud-sql-proxy"
+    - "{{ $.Values.global.projectID }}:{{ .cloudSQLProxy.region | default "europe-west3" }}:{{ .cloudSQLProxy.instanceName }}"
+    - "--auto-iam-authn"
+    - "--structured-logs"
+    - "--quitquitquit"
+    {{- if .cloudSQLProxy.secretKeyName }}
+    - "--credentials-file=/secrets/{{ .cloudSQLProxy.secretKeyName }}/key.json"
+    {{- end }}
+  securityContext:
+    runAsNonRoot: true
+  {{- if .cloudSQLProxy.secretKeyName }}
+  volumeMounts:
+    - name: {{ .cloudSQLProxy.secretKeyName }}
+      mountPath: "/secrets/{{ .cloudSQLProxy.secretKeyName }}"
+      readOnly: true
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/db-migration/templates/_helpers.tpl
+++ b/charts/db-migration/templates/_helpers.tpl
@@ -5,7 +5,7 @@
 
 {{- define "db-migration.labels" -}}
 app: {{ include "db-migration.name" $ | quote }}
-chart-name: {{ .Chart.Name | quote }}
+chart-name: "db-migration"
 chart-version: {{ .Chart.Version | quote }}
 {{- range $k, $v := .Values.global.labels }}
 {{ printf "%s: %s" $k ($v | quote) }}

--- a/charts/db-migration/templates/job.yaml
+++ b/charts/db-migration/templates/job.yaml
@@ -1,4 +1,4 @@
-{{ $types := list "Always" "OnFailure" "Never" }}
+{{ $types := list "OnFailure" "Never" }}
 {{- if not (has .Values.job.restartPolicy $types) }}
 {{- fail (printf "job.restartPolicy [%s] does not have a valid type. Valid type: %s" .Values.job.restartPolicy (join ", " $types)) }}
 {{- end }}

--- a/charts/db-migration/templates/job.yaml
+++ b/charts/db-migration/templates/job.yaml
@@ -1,100 +1,121 @@
+{{ $types := list "Always" "OnFailure" "Never" }}
+{{- if not (has .Values.job.restartPolicy $types) }}
+{{- fail (printf "job.restartPolicy [%s] does not have a valid type. Valid type: %s" .Values.job.restartPolicy (join ", " $types)) }}
+{{- end }}
+
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "db-migration.name" $ }}
-  {{- if or (.Values.job.annotations) (.Values.argoAnnotations.enable) }}
   annotations:
     {{- with .Values.job.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if .Values.argoAnnotations.enable }}
-    argocd.argoproj.io/sync-wave: {{ .Values.argoAnnotations.syncWave | quote }}
-    argocd.argoproj.io/hook: {{ .Values.argoAnnotations.syncPhase | quote }}
-    argocd.argoproj.io/hook-delete-policy: {{ .Values.argoAnnotations.hookDeletePolicy | quote }}
-    {{- end }}
-  {{- end }}
+    argocd.argoproj.io/sync-wave: {{ (.Values.argoAnnotations).syncWave | default "-2" | quote }}
+    argocd.argoproj.io/hook: {{ (.Values.argoAnnotations).syncPhase | default "Sync" }}
+    argocd.argoproj.io/hook-delete-policy: {{ (.Values.argoAnnotations).hookDeletePolicy | default "HookSucceeded" }}
   labels:
     {{- include "db-migration.labels" $ | nindent 4 }}
 spec:
-  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
-  backoffLimit: {{ .Values.job.backoffLimit }}
+  {{- with .Values.job }}
+  ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished }}
+  backoffLimit: {{ .backoffLimit | default "2" }}
   template:
+    {{- if .dataDogLogs.enable }}
     metadata:
-      {{- if or .Values.job.podAnnotations .Values.dataDogLogs.enable }}
       annotations:
-        {{- if.Values.dataDogLogs.enable }}
+        {{- if.dataDogLogs.enable }}
         ad.datadoghq.com/{{ include "db-migration.name" $ }}.logs: '[{"source": "{{ include "db-migration.name" $ }}", "service": "{{ include "db-migration.name" $ }}"}]'
         {{- end }}
-        {{- with .Values.job.podAnnotations }}
+        {{- with .podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- end }}
-
-      {{- if or .Values.job.podLabels .Values.dataDogLogs.enable }}
       labels:
-        {{- if.Values.dataDogLogs.enable }}
         tags.datadoghq.com/service: "{{ include "db-migration.name" $ }}"
-        tags.datadoghq.com/version: "{{ .Values.job.container.tag }}"
-        {{- end }}
-        {{- range $k, $v := .Values.job.podLabels }}
-        {{ printf "%s: %s" $k ($v | quote) }}
-        {{- end -}}
-      {{- end }}
+        tags.datadoghq.com/version: "{{ .container.tag }}"
+    {{- end }}
     spec:
-      {{- if .Values.job.imagePullSecrets }}
+      {{- if .imagePullSecrets }}
       imagePullSecrets:
-        {{- .Values.job.imagePullSecrets | toYaml | nindent 8 }}
+        {{- .imagePullSecrets | toYaml | nindent 8 }}
       {{- end }}
-      restartPolicy: {{ .Values.job.restartPolicy }}
-      shareProcessNamespace: {{ .Values.job.shareProcessNamespace }}
+      restartPolicy: {{ .restartPolicy }}
+      shareProcessNamespace: {{ .shareProcessNamespace | default "false" }}
+      serviceAccountName: {{ .serviceAccountName }}
       containers:
+        {{- with .container }}
         - name: dbup
-          image: "{{ .Values.job.container.image }}:{{ .Values.job.container.tag }}"
-          {{- with .Values.job.environment }}
+          image: "{{ .image }}:{{ .tag }}"
+
+          {{- if .command }}
+          command: {{ .command | toJson }}
+          {{- end }}
+
+          {{- if .args }}
+          args: {{ .args | toJson }}
+          {{- end }}
+
+          {{- if or .environment .fieldRefEnvironment }}
           env:
-          {{- range $name, $value := . }}
-          - name: {{ $name }}
-            value: {{ $value | quote }}
+            {{- range $name, $value := .environment }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- range $name, $value := .fieldRefEnvironment }}
+            - name: {{ $name }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: {{ $value }}
+            {{- end }}
           {{- end }}
-          {{- end }}
-          {{- with .Values.job.secrets }}
-          volumeMounts:
-          {{- range $secret := . }}
-          - name: {{ $secret }}
-            mountPath: /secrets/{{ $secret }}
-            readOnly: true
-          {{- end }}
+          
+          {{- if .envFromConfigmap }}
+          envFrom:
+            {{- range $cmName := .envFromConfigmap }}            
+            - configMapRef:
+              name: {{ $cmName }}
+            {{- end }}
           {{- end }}
 
-        {{- if .Values.job.cloudSQLProxy.enable }}
-        - name: cloud-sql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:{{ .Values.job.cloudSQLProxy.imageTag }}
-          command:
-            - "/cloud_sql_proxy"
-            - "-instances={{ .Values.job.cloudSQLProxy.projectId }}:{{ .Values.job.cloudSQLProxy.region }}:{{ .Values.job.cloudSQLProxy.instanceName }}=tcp:5432"
-            - "-credential_file=/secrets/{{ .Values.job.cloudSQLProxy.secretKeyName }}/key.json"
-            - "-enable_iam_login"
-          securityContext:
-            runAsNonRoot: true
+          {{- if or .secrets .configMaps }}
           volumeMounts:
-            - name: {{ .Values.job.cloudSQLProxy.secretKeyName }}
-              mountPath: /secrets/{{ .Values.job.cloudSQLProxy.secretKeyName }}
+            {{- range $secret := .secrets }}
+            - name: {{ $secret }}
+              mountPath: /secrets/{{ $secret }}
               readOnly: true
-        {{ end }}
-
-      {{- if or (.Values.job.cloudSQLProxy.enable) (.Values.job.secrets) }}
-      volumes:
-        {{- if .Values.job.cloudSQLProxy.enable }}
-        - name: {{ .Values.job.cloudSQLProxy.secretKeyName }}
-          secret:
-            secretName: {{ .Values.job.cloudSQLProxy.secretKeyName }}
+            {{- end }}
+            {{- range $configMap := .configMaps }}
+            - name: {{ $configMap.name }}
+              mountPath: {{ $configMap.mountPath }}
+            {{- end }}
+          {{- end }}
         {{- end }}
 
-        {{- range $secret := .Values.job.secrets }}
+        {{- if .cloudSQLProxy.enable }}
+        {{- include "db-migration.cloudSQLProxy" $ | nindent 8 }}
+        {{- end }}
+
+      {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.configMaps }}
+      volumes:
+        {{- if and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName }}
+        - name: {{ .cloudSQLProxy.secretKeyName }}
+          secret:
+            secretName: {{ .cloudSQLProxy.secretKeyName }}
+        {{- end }}
+
+        {{- with .container }}
+        {{- range $secret := .secrets }}
         {{- if not (and $.Values.job.cloudSQLProxy.enable (eq $.Values.job.cloudSQLProxy.secretKeyName $secret))}}
         - name: {{ $secret }}
           secret:
             secretName: {{ $secret }}
         {{- end }}
         {{- end }}
+        {{- range $configMap := .configMaps }}
+        - name: {{ $configMap.name }}
+          configMap:
+            name: {{ $configMap.name }}
+        {{- end }}
+        {{- end }}
       {{- end }}
+  {{- end }}

--- a/charts/db-migration/values.yaml
+++ b/charts/db-migration/values.yaml
@@ -24,7 +24,7 @@ job:
 
   # Possible values Always, OnFailure, and Never. Kubernetes default value is Always.
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
-  restartPolicy: Always
+  restartPolicy: Never
 
   # Clean up finished Jobs (either Complete or Failed) automatically is to use a TTL mechanism
   # provided by a TTL controller for finished resources.

--- a/charts/db-migration/values.yaml
+++ b/charts/db-migration/values.yaml
@@ -22,8 +22,8 @@ job:
   dataDogLogs:
     enable: false
 
-  # Possible values Always, OnFailure, and Never. Kubernetes default value is Always.
-  # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+  # Possible values are OnFailure or Never.
+  # https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-template
   restartPolicy: Never
 
   # Clean up finished Jobs (either Complete or Failed) automatically is to use a TTL mechanism

--- a/charts/db-migration/values.yaml
+++ b/charts/db-migration/values.yaml
@@ -2,64 +2,79 @@ global:
   # Add labels from a parent chart to all manifests.
   labels: {}
 
-# Override name of job/pod. If not set 'generate-name: db-migrate-' will be used.
+  # The Google Project ID.
+  # [Required for Cloud SQL Proxy]
+  projectID: some-id
+
+# Override name of the Job definition.
 fullnameOverride: ""
 
 ##################################################
 #                      Job                       #
 ##################################################
 
-# Below properties sets a ArgoCD Sync/Hook annotation.
-# https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/
-argoAnnotations:
-  enable: true
-  syncPhase: Sync
-  syncWave: -2
-  hookDeletePolicy: HookSucceeded
-
-# Enable DataDog logging.
-dataDogLogs:
-  enable: true
-
 job:
   # Labels and Annotations on the Job definition.
   labels: {}
   annotations: {}
 
-  # Labels and Annotations on the Pod template.
-  podLabels: {}
-  podAnnotations: {}
+  # Enable DataDog logging.
+  dataDogLogs:
+    enable: false
+
+  # Possible values Always, OnFailure, and Never. Kubernetes default value is Always.
+  # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+  restartPolicy: Always
+
+  # Clean up finished Jobs (either Complete or Failed) automatically is to use a TTL mechanism
+  # provided by a TTL controller for finished resources.
+  ttlSecondsAfterFinished: 120
+  
+  # Assign a service account for your application.
+  # This service account represents your application and is used for authentication
+  # with Workload Identity. The service account must be Workload Identity enabled.
+  serviceAccountName: default
 
   imagePullSecrets: []
-    #- secret-name-here
+    # - secret-name-here
 
   container:
     image: example-image
     tag: latest
 
-  environment: {}
-    # SOME_ENV: some-value
+    # Enable custom command
+    # command: ["my-command"]
+    # args: ["with", "--params=yes"]
 
-  secrets: []
-  # - very-secret
+    environment: {}
+      # SOME_ENV: some-value
 
-  # Time to live in seconds after the job has finished.
-  ttlSecondsAfterFinished: 120
+    envFromConfigmap: []
+      # - configmap-name
 
-  # backoffLimit specifies the number of re-tries before job controller gives up.
-  backoffLimit: 2
+    fieldRefEnvironment: {}
+      # SOME_ENV: some-field-reference
 
-  # Restart policy of pod fails.
-  restartPolicy: Never
+    # Below list of kubernetes secret names will be mounted into the container
+    # under the path /secrets/<secret-name>/<secret-key>
+    secrets: []
+    # - very-secret
 
-  # Share the same process namespace for all containers in the pod.
-  shareProcessNamespace: true
+    # Below list of configmaps will be mounted into he container.
+    configMaps: []
+    # - name: some-configmap
+    #   mountPath: /some/path
 
-  # Enable the Google Cloud SQL Proxy container.
+  # Enable the Google Cloud SQL Proxy sidecar
+  # Find the latest version here, https://gcr.io/cloudsql-docker/gce-proxy
   cloudSQLProxy:
-    enable: true
-    imageTag: 1.31.0
-    projectId: google-project-id
-    region: europe-west3
+    enable: false
     instanceName: sqlinstance-name
-    secretKeyName: google-service-account-key
+
+    # [Deprecated]
+    # If specified, Cloud SQL Proxy will use the provided credentials file for authn
+    # insted of application default login aka Workload Identity.
+    # secretKeyName: google-service-account-key
+
+    # Immutable, if not specified, region will default to europe-west3
+    # region: europe-west3


### PR DESCRIPTION
- ArgoCD config is now hidden defaults
- DataDog logs are now disabled by default
- Removed `shareProcessNamespace` option
- Added `envFromConfigmap` and `fieldRefEnvironment` options
- Added support for Google Workload Identity (Still supports a credentials file)
- Updated Cloud SQL Proxy to version 2
  - Includes structured logs
  - Is started with the `--quitquitquit` parameter

Cloud SQL Proxy version 2 now supports the `--quitquitquit` parameter, which means that when the migration job is done, you can send a POST request to `http://localhost:9091/quitquitquit` to terminate the Cloud SQL Proxy process. If not the job will continue to run.