### PR TITLE
fix: set static chart-name label

### DIFF
--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 
 {{- define "deployment.labels" -}}
 app: {{ include "deployment.name" $ | quote }}
-chart-name: {{ .Chart.Name | quote }}
+chart-name: simple-deployment
 chart-version: {{ .Chart.Version | quote }}
 {{- range $k, $v := .Values.global.labels }}
 {{ printf "%s: %s" $k ($v | quote) }}


### PR DESCRIPTION
The `chart-name` label is changed from `.Chart.Name` to `simple-deployment`.
The reason for this is that if the chart is given an alias the `.Chart.Name` is changed to that alias.