### PR TITLE
feat: cronjob added health check to sql proxy

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cronjob
 description: Kubernetes CronJob Resource
-version: 0.1.2
+version: 0.1.3
 

--- a/charts/cronjob/templates/_helper.tpl
+++ b/charts/cronjob/templates/_helper.tpl
@@ -25,6 +25,7 @@ ad.datadoghq.com/{{ .Values.name }}.logs: '[{"source": "{{ .Values.name }}", "se
     - "--auto-iam-authn"
     - "--structured-logs"
     - "--quitquitquit"
+    - "--health-check"
     {{- if .cloudSQLProxy.secretKeyName }}
     - "--credentials-file=/secrets/{{ .cloudSQLProxy.secretKeyName }}/key.json"
     {{- end }}


### PR DESCRIPTION
Enabled health check endpoint on the cloud sql proxy for Cronjob chart.