### PR TITLE
feat: support for subpaths on configmap volume mounts

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 1.0.1
+version: 1.0.2

--- a/charts/simple-deployment/templates/deployment.yaml
+++ b/charts/simple-deployment/templates/deployment.yaml
@@ -102,6 +102,9 @@ spec:
           {{- range $configMap := .configMaps }}
           - name: {{ $configMap.name }}
             mountPath: {{ $configMap.mountPath }}
+            {{- if $configMap.subPath }}
+            subPath: {{ $configMap.subPath }}
+            {{- end }}
           {{- end }}
           {{- range $volumeMount := .additionalVolumeMounts }}
           - name: {{ $volumeMount.name }}


### PR DESCRIPTION
I have made an update so we now can include a `subPath` to a `volumeMounts` if we only want to mount a single file into a given known folder.

This has been tested locally with:

**Chart.yaml**
```yaml
apiVersion: v2
name: testsubpathjob
description: A test job for testing subpath
version: 0.1.0
dependencies:
  - name: simple-deployment
    version: 1.0.2
```

**values.yaml**
```yaml
global:
  projectID: knp-emobility-test
simple-deployment:
  deployment:
    # Pod Replicas
    replicas: 3
    
    container:
      environment:
        APPSETTINGS_SELECTOR: test

      configMaps:
        - name: hubject-certificates
          mountPath: /certs
        - name: environment-configmap
          mountPath: /app/appsettings.cloud.json
          subPath: appsettings.cloud.json
        - name: environment-test-configmap
          mountPath: /app/appsettings.cloud.test.json
          subPath: appsettings.cloud.test.json
    
```

which produces the following when running `helm template .`
```yaml
# Source: testsubpathjob/charts/simple-deployment/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name
  labels:
    app: "release-name"
    chart-name: simple-deployment
    chart-version: "1.0.2"
spec:
  selector:
    matchLabels:
      app: release-name
  replicas: 3
  revisionHistoryLimit: 5
  template:
    metadata:
      labels:
        app: "release-name"
        chart-name: simple-deployment
        chart-version: "1.0.2"

    spec:
      serviceAccountName: default
      containers:
      - name: release-name
        image: "example-image:latest"
        securityContext:
          allowPrivilegeEscalation: false
          privileged: false
        resources:
          limits:
            cpu: 1000m
            memory: 2000Mi
          requests:
            cpu: 100m
            memory: 500Mi
        livenessProbe:
          httpGet:
            path: /healthz
            port:
          initialDelaySeconds: 5
          periodSeconds: 10
          timeoutSeconds: 1
          successThreshold: 1
          failureThreshold: 3
        readinessProbe:
          httpGet:
            path: /readyz
            port:
          initialDelaySeconds: 5
          periodSeconds: 10
          timeoutSeconds: 1
          successThreshold: 1
          failureThreshold: 3
        env:
          - name: APPSETTINGS_SELECTOR
            value: "test"
        volumeMounts:
          - name: hubject-certificates
            mountPath: /certs
          - name: environment-configmap
            mountPath: /app/appsettings.cloud.json
            subPath: appsettings.cloud.json
          - name: environment-test-configmap
            mountPath: /app/appsettings.cloud.test.json
            subPath: appsettings.cloud.test.json

      volumes:
        - name: hubject-certificates
          configMap:
            name: hubject-certificates
        - name: environment-configmap
          configMap:
            name: environment-configmap
        - name: environment-test-configmap
          configMap:
            name: environment-test-configmap
```

Focus is on `volumeMounts`:
```yaml
        volumeMounts:
          - name: hubject-certificates
            mountPath: /certs
          - name: environment-configmap
            mountPath: /app/appsettings.cloud.json
            subPath: appsettings.cloud.json
          - name: environment-test-configmap
            mountPath: /app/appsettings.cloud.test.json
            subPath: appsettings.cloud.test.json
```
Where `hubject-certificates` doesn't get a `subPath`, but the two other mounts does, because it has been specified in `values.yaml`.