### PR TITLE
feat: support for subpaths on configmap volume mounts for a cronjob

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 1.0.1
+version: 1.0.2

--- a/charts/simple-deployment/templates/deployment.yaml
+++ b/charts/simple-deployment/templates/deployment.yaml
@@ -102,6 +102,9 @@ spec:
           {{- range $configMap := .configMaps }}
           - name: {{ $configMap.name }}
             mountPath: {{ $configMap.mountPath }}
+            {{- if $configMap.subPath }}
+            subPath: {{ $configMap.subPath }}
+            {{- end }}
           {{- end }}
           {{- range $volumeMount := .additionalVolumeMounts }}
           - name: {{ $volumeMount.name }}


### PR DESCRIPTION
I have added the ability to add a `subPath` for `configMaps`. This has been tested locally, with this

**Chart.yaml**
```yaml
apiVersion: v2
name: testsubpathjob
description: A test job for testing subpath
version: 0.1.0
dependencies:
  - name: cronjob
    version: 0.1.5
    repository: file://../../charts/cronjob
```

**values.yaml**
```yaml
global:
  projectID: knp-emobility-test
cronjob:  
  job:
    # Pod Replicas
    replicas: 3
    
    container:
      environment:
        APPSETTINGS_SELECTOR: test
  
      configMaps:
        - name: hubject-certificates
          mountPath: /certs
        - name: environment-configmap
          mountPath: /app/appsettings.cloud.json
          subPath: appsettings.cloud.json
        - name: environment-test-configmap
          mountPath: /app/appsettings.cloud.test.json
          subPath: appsettings.cloud.test.json
```

which produces this, when running `helm template .`:

```yaml
---
# Source: testsubpathjob/charts/cronjob/templates/cronjob.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: cronjob-name
  labels:
    app: "release-name"
    chart-name: cronjob
    chart-version: "0.1.5"
spec:
  schedule: "0 1 * * *"
  successfulJobsHistoryLimit: 3
  failedJobsHistoryLimit: 1
  concurrencyPolicy: Allow
  jobTemplate:
    spec:
      backoffLimit: 6
      template:
        metadata:
        spec:
          serviceAccountName: default
          restartPolicy: Never
          containers:
          - name: cronjob-name
            image: "example-image:latest"
            resources:
              limits:
                cpu: 1000m
                memory: 2000Mi
              requests:
                cpu: 400m
                memory: 1000Mi
            env:
              - name: APPSETTINGS_SELECTOR
                value: "test"
            volumeMounts:
              - name: hubject-certificates
                mountPath: /certs
              - name: environment-configmap
                mountPath: /app/appsettings.cloud.json
                subPath: appsettings.cloud.json
              - name: environment-test-configmap
                mountPath: /app/appsettings.cloud.test.json
                subPath: appsettings.cloud.test.json
          volumes:
            - name: hubject-certificates
              configMap:
                name: hubject-certificates
            - name: environment-configmap
              configMap:
                name: environment-configmap
            - name: environment-test-configmap
              configMap:
                name: environment-test-configmap
```

The focus should here be on:
```yaml
            volumeMounts:
              - name: hubject-certificates
                mountPath: /certs
              - name: environment-configmap
                mountPath: /app/appsettings.cloud.json
                subPath: appsettings.cloud.json
              - name: environment-test-configmap
                mountPath: /app/appsettings.cloud.test.json
                subPath: appsettings.cloud.test.json
```

Where `environment-test-configmap` contains a `subPath` which has been specified in `values.yaml`, but `hubject-certificates` does not.

This has only been tested locally, and not i k8s yet.