### PR TITLE
fix: removed default func for backoffLimit prop

### DIFF
--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -32,7 +32,7 @@ spec:
   jobTemplate:
     {{- with .Values.job }}
     spec:
-      backoffLimit: {{ .backoffLimit | default 6 }}
+      backoffLimit: {{ .backoffLimit }}
       {{- if .ttlSecondsAfterFinished }}
       ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished }}
       {{- end }}


### PR DESCRIPTION
The template function `default` is preventing the usage of `backoffLimit: 0` because the default value is used if the value given is `null`, `false`, `0` or empty string/array.

Removed `default` function. The default value is already defined in the `values.yaml` file so it will not change anything.