### PR TITLE
fix: www redirect issue caused be faulty if statement

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 1.0.2
+version: 1.0.3

--- a/charts/simple-deployment/templates/ingress.yaml
+++ b/charts/simple-deployment/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.ingress.host }}
-    {{- if and .Values.ingress.wwwRedirect (eq .Values.ingress.ingressClassName "nginx") }}
+    {{- if .Values.ingress.wwwRedirect }}
     - "www.{{ .Values.ingress.host }}"
     {{- end }}
     secretName: "le-cert-{{ .Values.ingress.host | replace "." "-" | trunc 54 | trimSuffix "-" }}"

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -158,7 +158,6 @@ ingress:
 
   # Redirect www.example.org to example.org.
   # Use this for custmer facing sites to support old Boomer habits.
-  # Only supported if using NGINX and ingressClassName is "nginx".
   wwwRedirect: false
 
   # By default, this chart will create a pathType: Prefix on "/" for the service above.


### PR DESCRIPTION
The `.ingress.ingressClassName` property on the ingress def was removed in `1.0`. The `wwwRedirect`  feature was dependent on that and therefore would always evaluate to false.