### PR TITLE
feat: added health check and structured logs args to cloud sql proxy

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 1.0.3
+version: 1.1.0

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -63,11 +63,13 @@ failureThreshold: {{ .readinessProbe.failureThreshold | default 3 }}
 {{- end -}}
 
 - name: cloud-sql-proxy
-  image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .cloudSQLProxy.imageTag | default "2.5.0" }}"
+  image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .cloudSQLProxy.imageTag | default "2.7" }}"
   command:
     - "/cloud-sql-proxy"
     - "{{ $projectID }}:{{ .cloudSQLProxy.region | default "europe-west3" }}:{{ .cloudSQLProxy.instanceName }}"
     - "--auto-iam-authn"
+    - "--structured-logs"
+    - "--health-check"
     {{- if .cloudSQLProxy.secretKeyName }}
     - "--credentials-file=/secrets/{{ .cloudSQLProxy.secretKeyName }}/key.json"
     {{- end }}


### PR DESCRIPTION
Added `--structured-logs` and `--health-check` arguments on the Cloud SQL Proxy in the `simple-deployment` chart. Also bumped the tag of the image to `2.7`.