### PR TITLE
fix: Remove unused parameter project name datadog monitor

### DIFF
--- a/charts/datadog-monitor/Chart.yaml
+++ b/charts/datadog-monitor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: datadog-monitor
 description: A Helm chart for deploying datadog monitors.
-version: 0.1.1
+version: 0.1.2

--- a/charts/datadog-monitor/values.yaml
+++ b/charts/datadog-monitor/values.yaml
@@ -12,10 +12,6 @@ global:
 # rememeber to explicitly set this to false in environments other than production. 
 enableAllMonitors: false
 
-# Required
-# The name of the your project.
-projectName:
-
 # Labels for the Kubernetes DatadogMonitor object.
 monitorLabels: {}
 


### PR DESCRIPTION
Removed the `projectName` property since it is not in use.