### PR TITLE
feat: Add GoogleSecretManager to Devx helm chart

### DIFF
--- a/charts/devx-dashboard/Chart.yaml
+++ b/charts/devx-dashboard/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: devx-dashboard
 
 description: A developer dashboard for releasing software
-version: 2.0.0
+version: 2.1.0-rc1
 appVersion: 2.0.10
 dependencies:
 - name: iam-service-account
-  version: 2.0.0
+  version: 2.1.0
   repository: https://ok-amba.github.io/config-connector-helm
   alias: iamServiceAccount
   condition: deadLetter.enabled

--- a/charts/devx-dashboard/values.yaml
+++ b/charts/devx-dashboard/values.yaml
@@ -157,6 +157,7 @@ iamServiceAccount:
 
   # Workload Identity allows workloads in your GKE clusters to impersonate Identity and
   # Access Management (IAM) service accounts to access Google Cloud services.
+  googleSecretManagerAccess: false
   workloadIdentity:
     enabled: true
 


### PR DESCRIPTION
Add an option to enable googleSecretManager in the Devx Portal