### PR TITLE
Legend-deployment: Support multiple hosts for Ingress

### DIFF
--- a/charts/legend-deployment/Chart.yaml
+++ b/charts/legend-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: legend-deployment
 description: A Helm chart for a legend deployment, incl. service and ingress, while also have support for gatekeeper and environment variable secrets
-version: 0.1.0-rc
+version: 0.1.0

--- a/charts/legend-deployment/Chart.yaml
+++ b/charts/legend-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: legend-deployment
 description: A Helm chart for a legend deployment, incl. service and ingress, while also have support for gatekeeper and environment variable secrets
-version: 0.0.1
+version: 0.1.0-rc

--- a/charts/legend-deployment/templates/additionalIngress.yaml
+++ b/charts/legend-deployment/templates/additionalIngress.yaml
@@ -2,7 +2,7 @@
 {{- fail "The service is not enabled, which is a dependency for the ingress."}}
 {{- end }}
 
-{{- if and (and (.Values.ingress.enable) (.Values.service.enable)) .Values.ingress.additionalHosts }}
+{{- if and (and (.Values.ingress.enable) (.Values.service.enable)) (and .Values.ingress.additionalIngress.enable .Values.ingress.additionalIngress.hosts)}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -16,7 +16,7 @@ metadata:
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
-    cert-manager.io/cluster-issuer: cloudflare-dns01-issuer
+    cert-manager.io/cluster-issuer:  {{ $.Values.ingress.additionalHosts.clusterIssuer | default "cloudflare-dns01-issuer" }}
   labels:
     {{- include "deployment.labels" $ | nindent 4 }}
     {{- range $k, $v := .labels }}
@@ -26,7 +26,7 @@ metadata:
 spec:
   ingressClassName: {{ $.Values.ingress.ingressClassName | default "nginx" }}
   rules:
-  {{- range $host := $.Values.ingress.additionalHosts }}
+  {{- range $host := $.Values.ingress.additionalHosts.hosts }}
   - host: {{ $host | quote }}
     http:
       paths:
@@ -42,7 +42,7 @@ spec:
         {{- end }}
 {{- end }}
   tls:
-  {{- range $host := $.Values.ingress.additionalHosts }}
+  {{- range $host := $.Values.ingress.additionalHosts.hosts }}
   - hosts:
     - {{ $host | quote }}
     {{- if $.Values.ingress.wwwRedirect }}

--- a/charts/legend-deployment/templates/additionalIngress.yaml
+++ b/charts/legend-deployment/templates/additionalIngress.yaml
@@ -16,7 +16,7 @@ metadata:
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
-    cert-manager.io/cluster-issuer:  {{ $.Values.ingress.additionalHosts.clusterIssuer | default "cloudflare-dns01-issuer" }}
+    cert-manager.io/cluster-issuer:  {{ $.Values.ingress.additionalIngress.clusterIssuer | default "cloudflare-dns01-issuer" }}
   labels:
     {{- include "deployment.labels" $ | nindent 4 }}
     {{- range $k, $v := .labels }}
@@ -26,7 +26,7 @@ metadata:
 spec:
   ingressClassName: {{ $.Values.ingress.ingressClassName | default "nginx" }}
   rules:
-  {{- range $host := $.Values.ingress.additionalHosts.hosts }}
+  {{- range $host := $.Values.ingress.additionalIngress.hosts }}
   - host: {{ $host | quote }}
     http:
       paths:
@@ -42,7 +42,7 @@ spec:
         {{- end }}
 {{- end }}
   tls:
-  {{- range $host := $.Values.ingress.additionalHosts.hosts }}
+  {{- range $host := $.Values.ingress.additionalIngress.hosts }}
   - hosts:
     - {{ $host | quote }}
     {{- if $.Values.ingress.wwwRedirect }}

--- a/charts/legend-deployment/templates/additionalIngress.yaml
+++ b/charts/legend-deployment/templates/additionalIngress.yaml
@@ -1,0 +1,56 @@
+{{- if and .Values.ingress.enable (not .Values.service.enable)}}
+{{- fail "The service is not enabled, which is a dependency for the ingress."}}
+{{- end }}
+
+{{- if and (and (.Values.ingress.enable) (.Values.service.enable)) .Values.ingress.additionalHosts }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "deployment.name" $ }}
+  {{- with $.Values.ingress }}
+  annotations:
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .wwwRedirect }}
+    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
+    {{- end }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
+    cert-manager.io/cluster-issuer: cloudflare-dns-issuer
+  labels:
+    {{- include "deployment.labels" $ | nindent 4 }}
+    {{- range $k, $v := .labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
+    {{- end }}
+    {{- if .createDNSRecord }}
+    external-dns-create: "true"
+    {{- end }}
+  {{- end }}
+spec:
+  ingressClassName: {{ $.Values.ingress.ingressClassName | default "nginx" }}
+  rules:
+  {{- range $host := $.Values.ingress.additionalHosts }}
+  - host: {{ $host | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "deployment.name" $ }}
+            port:
+              number: {{ $.Values.deployment.container.containerPort | required "A container port is required on the container." }}
+        {{- with $.Values.ingress.additionalPaths }}
+        {{ toYaml . | nindent 6}}
+        {{- end }}
+{{- end }}
+  tls:
+  {{- range $host := $.Values.ingress.additionalHosts }}
+  - hosts:
+    - {{ $host | quote }}
+    {{- if $.Values.ingress.wwwRedirect }}
+    - "www.{{ $host }}"
+    {{- end }}
+    secretName: "le-cert-{{ $host | replace "." "-" | trunc 54 | trimSuffix "-" }}"
+  {{ end }}
+{{- end }}

--- a/charts/legend-deployment/templates/additionalIngress.yaml
+++ b/charts/legend-deployment/templates/additionalIngress.yaml
@@ -16,7 +16,7 @@ metadata:
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
-    cert-manager.io/cluster-issuer: cloudflare-dns-issuer
+    cert-manager.io/cluster-issuer: cloudflare-dns01-issuer
   labels:
     {{- include "deployment.labels" $ | nindent 4 }}
     {{- range $k, $v := .labels }}

--- a/charts/legend-deployment/templates/additionalIngress.yaml
+++ b/charts/legend-deployment/templates/additionalIngress.yaml
@@ -6,7 +6,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "deployment.name" $ }}
+  name: {{ include "deployment.name" $ }}-additional
   {{- with $.Values.ingress }}
   annotations:
     {{- with .annotations }}

--- a/charts/legend-deployment/templates/additionalIngress.yaml
+++ b/charts/legend-deployment/templates/additionalIngress.yaml
@@ -22,9 +22,6 @@ metadata:
     {{- range $k, $v := .labels }}
     {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
-    {{- if .createDNSRecord }}
-    external-dns-create: "true"
-    {{- end }}
   {{- end }}
 spec:
   ingressClassName: {{ $.Values.ingress.ingressClassName | default "nginx" }}

--- a/charts/legend-deployment/tests/additionalIngress_test.yaml
+++ b/charts/legend-deployment/tests/additionalIngress_test.yaml
@@ -1,0 +1,56 @@
+suite: Additional Ingress tests
+templates:
+  - additionalIngress.yaml
+tests:
+  - it: "Should not render additional ingress object when disabled"
+    set:
+      deployment.container.containerPort: 8080
+      service.enable: true
+      ingress.enable: true
+      ingress.additionalIngress.enable: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: "Should not render additional ingress object when enabled, but no additional hosts"
+    set:
+      deployment.container.containerPort: 8080
+      service.enable: true
+      ingress.enable: true
+      ingress.additionalIngress.enable: true
+      ingress.additionalIngress.hosts: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "Should render additional ingress object when enabled and has additional hosts"
+    set:
+      deployment.container.containerPort: 8080
+      service.enable: true
+      ingress.enable: true
+      ingress.additionalIngress.enable: true
+      ingress.additionalIngress.hosts: ["ingress-test.test.okdc.dk"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: "cloudflare-dns01-issuer"
+      - lengthEqual:
+          path: "spec.rules"
+          count: 1
+      - lengthEqual:
+          path: "spec.tls"
+          count: 1
+
+  - it: "Should allow specifying different issuers"
+    set:
+      deployment.container.containerPort: 8080
+      service.enable: true
+      ingress.enable: true
+      ingress.additionalIngress.enable: true
+      ingress.additionalIngress.hosts: ["ingress-test.test.okdc.dk"]
+      ingress.additionalIngress.clusterIssuer: nginx-http01
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: "nginx-http01"

--- a/charts/legend-deployment/values.yaml
+++ b/charts/legend-deployment/values.yaml
@@ -192,8 +192,7 @@ ingress:
   host: example.org
 
   # Additional URLs e.g. old service URLs that needs to be routable during migration.
-  # The Cloudflare DNS Issuer will be used, when "createDNSRecord" is set to "true".
-  # All entries in "additionalHosts" must be in the ok.dk domain, when setting "createDNSRecord" to "true".
+  # Any additional hosts will be issued certificates using the Cloudflare DNS ClusterIssuer through DNS01 challenges.
   additionalHosts: []
 
   # Create cname records

--- a/charts/legend-deployment/values.yaml
+++ b/charts/legend-deployment/values.yaml
@@ -191,6 +191,11 @@ ingress:
   # URL of the application
   host: example.org
 
+  # Additional URLs e.g. old service URLs that needs to be routable during migration.
+  # The Cloudflare DNS Issuer will be used, when "createDNSRecord" is set to "true".
+  # All entries in "additionalHosts" must be in the ok.dk domain, when setting "createDNSRecord" to "true".
+  additionalHosts: []
+
   # Create cname records
   createDNSRecord: true
 

--- a/charts/legend-deployment/values.yaml
+++ b/charts/legend-deployment/values.yaml
@@ -191,9 +191,12 @@ ingress:
   # URL of the application
   host: example.org
 
-  # Additional URLs e.g. old service URLs that needs to be routable during migration.
-  # Any additional hosts will be issued certificates using the Cloudflare DNS ClusterIssuer through DNS01 challenges.
-  additionalHosts: []
+  additionalIngress: 
+    enable: false
+    clusterIssuer: null 
+    # Additional URLs e.g. old service URLs that needs to be routable during migration.
+    hosts: []
+    
 
   # Create cname records
   createDNSRecord: true


### PR DESCRIPTION
The following PR introduces support for multiple hosts in an additional opt-in Ingress object that uses the Cloudflare DNS ClusterIssuer for certificates. 
The change is required to handle routing and certificates for the "old" URLs for the services that are being migrated from legacy cluster to Gen2 / shiny cluster. 

I have currently verified the following: 
* Legend-deployment can deploy to cluster with additional Ingress
* Requests using a host under `additionalHosts` routes to the expected pod
* Cloudflare DNS ClusterIssuer issues a certificate as expected: 
![image](https://github.com/user-attachments/assets/5755915c-ab63-44c9-9956-486f15acf0c4)