### PR TITLE
nats-streaming (fix): Set kubernetes namespace explicitly  to fix cluster routes DNS resolution. 

### DIFF
--- a/charts/nats-streaming/Chart.yaml
+++ b/charts/nats-streaming/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: nats-streaming
 description: Stan helm chart fork that supports configuring auth through secrets. Only used for migration purposes and no maintenance effort planned. 
-version: 0.1.0-rc-1
+version: 0.1.0-rc2

--- a/charts/nats-streaming/templates/_helpers.tpl
+++ b/charts/nats-streaming/templates/_helpers.tpl
@@ -42,6 +42,6 @@ Return the NATS cluster routes.
 {{- define "nats.clusterRoutes" -}}
 {{- $name := default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- range $i, $e := until (.Values.stan.replicas | int) -}}
-{{- printf "nats://%s-%d.%s.%s.svc:6222," $name $i $name $.Release.Namespace -}}
+{{- printf "nats://%s-%d.%s.%s.svc:6222," $name $i $name $.Values.kubernetesNamespace -}}
 {{- end -}}
 {{- end }}

--- a/charts/nats-streaming/templates/serviceMonitor.yaml
+++ b/charts/nats-streaming/templates/serviceMonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Values.exporter.serviceMonitor.namespace }}
   namespace: {{ .Values.exporter.serviceMonitor.namespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ $.Values.kubernetesNamespace | quote }}
   {{- end }}
   {{- if .Values.exporter.serviceMonitor.labels }}
   labels:

--- a/charts/nats-streaming/templates/validation-checks.yaml
+++ b/charts/nats-streaming/templates/validation-checks.yaml
@@ -1,0 +1,3 @@
+ {{- if (not ($.Values.kubernetesNamespace)) }}
+    {{- fail "namespace must for cluster service DNS lookup to work correctly." }}
+ {{- end }}

--- a/charts/nats-streaming/values.yaml
+++ b/charts/nats-streaming/values.yaml
@@ -3,6 +3,7 @@
 #  NATS Streaming Configuration  #
 #                                #
 ##################################
+kubernetesNamespace: 
 stan:
   image: nats-streaming:0.25.6
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Previously the nats-conf used `$.Release.Namespace` to set the cluster routes. This would prevent the cluster from connecting to each other, since DNS resolution would fail. DNS resolution fails, since we run a `helm template` in our pipelines, which makes `$.Release.Namespace` resolve to `default`. 

This PR introduces a new required property in `values.yaml` that allows setting the kubernetes namespace explicitly.