### PR TITLE
[Release candidate 3] nats-streaming (feat): Add support for enabling NodePort 

### DIFF
--- a/charts/nats-streaming/Chart.yaml
+++ b/charts/nats-streaming/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: nats-streaming
 description: Stan helm chart fork that supports configuring auth through secrets. Only used for migration purposes and no maintenance effort planned. 
-version: 0.1.0-rc2
+version: 0.1.0-rc3

--- a/charts/nats-streaming/templates/nodePort.yaml
+++ b/charts/nats-streaming/templates/nodePort.yaml
@@ -1,0 +1,19 @@
+---
+{{- if $.Values.nodePort.enable }}
+apiVersion: v1
+kind: Service
+type: NodePort
+metadata:
+  name: {{ template "stan.name" . }}
+  labels:
+    app: {{ template "stan.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  selector:
+    app: {{ template "stan.name" . }}
+  ports:
+    - nodePort: {{ $.Values.nodePort.nodePort}}
+      port: 4222
+      protocol: TCP
+      targetPort: 4222
+{{- end }}

--- a/charts/nats-streaming/templates/nodePort.yaml
+++ b/charts/nats-streaming/templates/nodePort.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 type: NodePort
 metadata:
-  name: {{ template "stan.name" . }}
+  name: {{ template "stan.name" . }}-nodeport
   labels:
     app: {{ template "stan.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/nats-streaming/templates/nodePort.yaml
+++ b/charts/nats-streaming/templates/nodePort.yaml
@@ -2,13 +2,13 @@
 {{- if $.Values.nodePort.enable }}
 apiVersion: v1
 kind: Service
-type: NodePort
 metadata:
   name: {{ template "stan.name" . }}-nodeport
   labels:
     app: {{ template "stan.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
+  type: NodePort
   selector:
     app: {{ template "stan.name" . }}
   ports:

--- a/charts/nats-streaming/templates/validation-checks.yaml
+++ b/charts/nats-streaming/templates/validation-checks.yaml
@@ -1,3 +1,7 @@
  {{- if (not ($.Values.kubernetesNamespace)) }}
     {{- fail "namespace must for cluster service DNS lookup to work correctly." }}
  {{- end }}
+
+ {{- if or (lt $.Values.nodePort.port 30000) (gt $.Values.nodePort.port 32767) }}
+    {{- fail (printf "specified port %d is outside of the cluster's node port range (30000-32767)" $.Values.nodePort.port) }}
+ {{- end }}

--- a/charts/nats-streaming/templates/validation-checks.yaml
+++ b/charts/nats-streaming/templates/validation-checks.yaml
@@ -1,7 +1,13 @@
  {{- if (not ($.Values.kubernetesNamespace)) }}
-    {{- fail "namespace must for cluster service DNS lookup to work correctly." }}
+    {{- fail "namespace must be set for cluster service DNS lookup to work correctly." }}
  {{- end }}
 
- {{- if or (lt $.Values.nodePort.port 30000) (gt $.Values.nodePort.port 32767) }}
-    {{- fail (printf "specified port %d is outside of the cluster's node port range (30000-32767)" $.Values.nodePort.port) }}
+{{- if $.Values.nodePort.enable }}
+ {{- if not $.Values.nodePort.nodePort }}
+    {{- fail "nodePort.nodePort must be set if nodePort.enable has been set to true" }}
  {{- end }}
+
+ {{- if or (lt (int $.Values.nodePort.nodePort) (int 30000)) (gt (int $.Values.nodePort.nodePort) (int 32767)) }}
+    {{- fail (printf "specified port %d is outside of the cluster's node port range (30000-32767)" $.Values.nodePort.nodePort) }}
+ {{- end }}
+{{- end }}

--- a/charts/nats-streaming/values.yaml
+++ b/charts/nats-streaming/values.yaml
@@ -1,9 +1,11 @@
+kubernetesNamespace: 
+nameOverride: ""
+imagePullSecrets: []
 ##################################
 #                                #
 #  NATS Streaming Configuration  #
 #                                #
 ##################################
-kubernetesNamespace: 
 stan:
   image: nats-streaming:0.25.6
   pullPolicy: IfNotPresent
@@ -29,8 +31,6 @@ stan:
       usernameKey: 
       passwordKey:
 
-nameOverride: ""
-imagePullSecrets: []
 serviceAccountName: ""
 
 # Annotations to add to the NATS pods
@@ -85,6 +85,19 @@ livenessProbe:
       path: /
       port: monitor
     timeoutSeconds: 2
+
+############################
+#                          #
+#  NodePort configuration  #
+#                          #
+############################
+nodePort: 
+ # Enable the NodePort service definition.
+  enable: false
+
+  # Port that will be exposed.
+  nodePort: 
+  
 
 ###########################
 #                         #


### PR DESCRIPTION
The on-prem legacy cluster exposed NATS to G4 through NodePort services. 
I have tried with a LoadBalancer service, but it does not seem like we have any LoadBalancer capabilities deployed to the cluster such as MetalLB. 