### PR TITLE
(feat) Legend-Deployment: Add additional ingress for legend-deployment

### DIFF
--- a/charts/legend-deployment/Chart.yaml
+++ b/charts/legend-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: legend-deployment
 description: A Helm chart for a legend deployment, incl. service and ingress, while also have support for gatekeeper and environment variable secrets
-version: 1.0.0
+version: 1.1.0

--- a/charts/legend-deployment/templates/additionalIngress.yaml
+++ b/charts/legend-deployment/templates/additionalIngress.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.ingress.enable (not .Values.service.enable)}}
+{{- fail "The service is not enabled, which is a dependency for the ingress."}}
+{{- end }}
+
+{{- if and (and (.Values.ingress.enable) (.Values.service.enable)) (and .Values.ingress.additionalIngress.enable .Values.ingress.additionalIngress.hosts)}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "deployment.name" $ }}-additional
+  {{- with $.Values.ingress }}
+  annotations:
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .wwwRedirect }}
+    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
+    {{- end }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
+    cert-manager.io/cluster-issuer:  {{ $.Values.ingress.additionalIngress.clusterIssuer | default "cloudflare-dns01-issuer" }}
+  labels:
+    {{- include "deployment.labels" $ | nindent 4 }}
+    {{- range $k, $v := .labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  ingressClassName: {{ $.Values.ingress.ingressClassName | default "nginx" }}
+  rules:
+  {{- range $host := $.Values.ingress.additionalIngress.hosts }}
+  - host: {{ $host | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "deployment.name" $ }}
+            port:
+              number: {{ $.Values.deployment.container.containerPort | required "A container port is required on the container." }}
+        {{- with $.Values.ingress.additionalPaths }}
+        {{ toYaml . | nindent 6}}
+        {{- end }}
+{{- end }}
+  tls:
+  {{- range $host := $.Values.ingress.additionalIngress.hosts }}
+  - hosts:
+    - {{ $host | quote }}
+    {{- if $.Values.ingress.wwwRedirect }}
+    - "www.{{ $host }}"
+    {{- end }}
+    secretName: "le-cert-{{ $host | replace "." "-" | trunc 54 | trimSuffix "-" }}"
+  {{ end }}
+{{- end }}

--- a/charts/legend-deployment/tests/additionalIngress_test.yaml
+++ b/charts/legend-deployment/tests/additionalIngress_test.yaml
@@ -1,0 +1,56 @@
+suite: Additional Ingress tests
+templates:
+  - additionalIngress.yaml
+tests:
+  - it: "Should not render additional ingress object when disabled"
+    set:
+      deployment.container.containerPort: 8080
+      service.enable: true
+      ingress.enable: true
+      ingress.additionalIngress.enable: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: "Should not render additional ingress object when enabled, but no additional hosts"
+    set:
+      deployment.container.containerPort: 8080
+      service.enable: true
+      ingress.enable: true
+      ingress.additionalIngress.enable: true
+      ingress.additionalIngress.hosts: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "Should render additional ingress object when enabled and has additional hosts"
+    set:
+      deployment.container.containerPort: 8080
+      service.enable: true
+      ingress.enable: true
+      ingress.additionalIngress.enable: true
+      ingress.additionalIngress.hosts: ["ingress-test.test.okdc.dk"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: "cloudflare-dns01-issuer"
+      - lengthEqual:
+          path: "spec.rules"
+          count: 1
+      - lengthEqual:
+          path: "spec.tls"
+          count: 1
+
+  - it: "Should allow specifying different issuers"
+    set:
+      deployment.container.containerPort: 8080
+      service.enable: true
+      ingress.enable: true
+      ingress.additionalIngress.enable: true
+      ingress.additionalIngress.hosts: ["ingress-test.test.okdc.dk"]
+      ingress.additionalIngress.clusterIssuer: nginx-http01
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: "nginx-http01"

--- a/charts/legend-deployment/values.yaml
+++ b/charts/legend-deployment/values.yaml
@@ -190,6 +190,13 @@ ingress:
 
   # URL of the application
   host: example.org
+  
+  additionalIngress: 
+    enable: false
+    clusterIssuer: null 
+    # Additional URLs e.g. old service URLs that needs to be routable during migration.
+    hosts: []
+    
 
   # Create cname records
   createDNSRecord: true


### PR DESCRIPTION
Adds an additional ingress object for supporting old "ok.dk" URLs during migration 