### PR TITLE
nats-streaming: Add fork of "stan" Helm Chart 

### DIFF
--- a/charts/nats-streaming/.helmignore
+++ b/charts/nats-streaming/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/nats-streaming/Chart.yaml
+++ b/charts/nats-streaming/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: nats-streaming
+description: Stan helm chart fork that supports configuring auth through secrets. Only used for migration purposes and no maintenance effort planned. 
+version: 0.1.0-rc7

--- a/charts/nats-streaming/Chart.yaml
+++ b/charts/nats-streaming/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: nats-streaming
 description: Stan helm chart fork that supports configuring auth through secrets. Only used for migration purposes and no maintenance effort planned. 
-version: 0.1.0-rc7
+version: 0.1.0

--- a/charts/nats-streaming/README.md
+++ b/charts/nats-streaming/README.md
@@ -1,0 +1,6 @@
+# NATS-streaming Chart
+
+Fork of https://github.com/nats-io/k8s/blob/main/helm/charts/stan/values.yaml that allows specifying auth credentials through a secret. The auth credentials can also be synced through an ExternalSecret using the `stan.auth.secretRef.externalSecret` options.
+This fork also removes a lot of the original configuration options as well as setting some default values that are specific to the Gen 2 on-prem cluster.
+
+There will be no maintenance efforts for this chart other than fixes to critical bugs and secrutiy issues.

--- a/charts/nats-streaming/templates/_helpers.tpl
+++ b/charts/nats-streaming/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{/*
+Expand the name of the chart.
+*/}}
+{{- define "stan.name" -}}
+{{- default (printf "%s-%s" .Release.Name $.Values.kubernetesNamespace) .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the list of peers in a NATS Streaming cluster.
+*/}}
+{{- define "stan.clusterPeers" -}}
+{{- range $i, $e := until (int $.Values.stan.replicas) -}}
+{{- printf "'%s-%d'," (include "stan.name" $) $i -}}
+{{- end -}}
+{{- end }}
+
+{{- define "stan.replicaCount" -}}
+{{- $replicas := (int $.Values.stan.replicas) -}}
+{{- if and $.Values.store.cluster.enabled (lt $replicas 3) -}}
+{{- $replicas = "" -}}
+{{- end -}}
+{{ print $replicas }}
+{{- end -}}
+
+{{/*
+Define the serviceaccountname
+*/}}
+{{- define "stan.serviceAccountName" -}}
+{{- default "nats-streaming" .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the proper NATS image name
+*/}}
+{{- define "nats.clusterAdvertise" -}}
+{{- printf "$(POD_NAME).%s.$(POD_NAMESPACE).svc" (include "stan.name" . ) }}
+{{- end }}
+
+{{/*
+Return the NATS cluster routes.
+*/}}
+{{- define "nats.clusterRoutes" -}}
+{{- $name := default (printf "%s-%s" .Release.Name $.Values.kubernetesNamespace) .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- range $i, $e := until (.Values.stan.replicas | int) -}}
+{{- printf "nats://%s-%d.%s.%s.svc:6222," $name $i $name $.Values.kubernetesNamespace -}}
+{{- end -}}
+{{- end }}

--- a/charts/nats-streaming/templates/configmap.yaml
+++ b/charts/nats-streaming/templates/configmap.yaml
@@ -1,0 +1,147 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "stan.name" . }}-config
+  labels:
+    app: {{ template "stan.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+data:
+  stan.conf: |-
+    #########################
+    # NATS Streaming Config #
+    #########################
+    streaming {
+      {{- if .Values.stan.clusterID }}
+      id: {{ .Values.stan.clusterID }}
+      {{- else }}
+      id: {{ template "stan.name" . }}
+      {{- end }}
+
+      {{- if .Values.stan.logging.debug }}
+      sd: true
+      {{- end }}
+      {{- if .Values.stan.logging.trace }}
+      sv: true
+      {{- end }}
+
+      {{- if .Values.stan.credentials }}
+      credentials: "/etc/stan-creds/{{ .Values.stan.credentials.secret.key }}"
+      {{- end }}
+
+      {{- if .Values.stan.auth.enabled }}
+      {{- if (and .Values.stan.auth.username .Values.stan.auth.password) }}
+      username: $AUTH_USER
+      password: $AUT_PASSWORD
+      {{- end }}
+
+      {{- if .Values.stan.auth.token }}
+      token: {{ .Values.stan.auth.token }}
+      {{- end }}
+
+      {{- if .Values.stan.auth.nkeySeedFile }}
+      nkey_seed_file: "/etc/nkey-seed-file"
+      {{- end }}
+      {{- end }}
+
+      {{- with .Values.store.ft.group }}
+      ft_group_name: {{ . }}
+      {{- end }}
+
+      ###############################
+      #  Store Config               #
+      ###############################
+      store: "file"
+      dir: {{ .Values.store.file.path }}
+      {{- with .Values.store.file.options }}
+      file_options: {{ toPrettyJson . | indent 6 }}
+      {{- end }}
+
+      {{- if .Values.store.cluster.enabled }}
+      ###############################
+      #  NATS Streaming Clustering  #
+      ###############################
+      cluster {
+        node_id: $POD_NAME
+        {{- with .Values.store.cluster.logPath }}
+        log_path: {{ . }}
+        {{- end }}
+
+        # Explicit names of resulting peers
+        peers: [
+          {{ template "stan.clusterPeers" . }}
+        ]
+      }
+      {{- end }}
+
+      {{- with .Values.store.partitioning }}
+      partitioning: {{ .enabled }}
+      {{- end }}
+
+      {{- with .Values.store.limits }}
+      store_limits: {
+        {{- if kindIs "float64" .max_channels }}
+        max_channels: {{ .max_channels | int }}
+        {{- end }}
+
+        {{- if kindIs "float64" .max_msgs }}
+        max_msgs: {{ .max_msgs | int }}
+        {{- end }}
+
+        {{- if .max_bytes }}
+        max_bytes: {{ .max_bytes }}
+        {{- end }}
+
+        {{- if .max_age }}
+        max_age: {{ .max_age | quote }}
+        {{- end }}
+
+        {{- if kindIs "float64" .max_subs }}
+        max_subs: {{ .max_subs | int }}
+        {{- end }}
+
+        {{- if .max_inactivity }}
+        max_inactivity: {{ .max_inactivity | quote }}
+        {{- end }}
+
+        {{- if .channels }}
+
+        channels {
+        {{- range $channel, $limits := .channels }}
+          {{ $channel }}: {
+            {{- if $limits }}
+
+            {{- if kindIs "float64" $limits.max_subs }}
+            max_subs: {{ $limits.max_subs | int }}
+            {{- end }}
+
+            {{- if kindIs "float64" $limits.max_msgs }}
+            max_msgs: {{ $limits.max_msgs | int }}
+            {{- end }}
+
+            {{- if $limits.max_bytes }}
+            max_bytes: {{ $limits.max_bytes }}
+            {{- end }}
+
+            {{- if $limits.max_age }}
+            max_age: {{ $limits.max_age | quote }}
+            {{- end }}
+
+            {{- if $limits.max_inactivity }}
+            max_inactivity: {{ $limits.max_inactivity | quote }}
+            {{- end }}
+          {{- end }}
+          }
+        {{- end }}
+        }
+        {{- end }}
+      }
+      {{- end }}
+    }
+
+    ###############################################
+    #                                             #
+    #            Embedded NATS Config             #
+    #                                             #
+    ###############################################
+    {{ include "nats-configmap" . | nindent 4 }}

--- a/charts/nats-streaming/templates/externalsecret.yaml
+++ b/charts/nats-streaming/templates/externalsecret.yaml
@@ -1,4 +1,4 @@
-{{- if and $.Values.stan.auth.enabled $.Values.stan.auth.secretRef.externalSecret.enable }}
+{{- if and $.Values.stan.auth.enabled $.Values.stan.auth.secretRef.externalSecret.enabled }}
 ---
 {{- $secretName := ($.Values.stan.auth.secretRef.secret | default "google-secret-manager") }}
 apiVersion: external-secrets.io/v1beta1

--- a/charts/nats-streaming/templates/externalsecret.yaml
+++ b/charts/nats-streaming/templates/externalsecret.yaml
@@ -1,0 +1,23 @@
+{{- if and $.Values.stan.auth.enabled $.Values.stan.auth.secretRef.externalSecret.enable }}
+---
+{{- $secretName := ($.Values.stan.auth.secretRef.secret | default "google-secret-manager") }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $.Values.stan.auth.secretRef.secret }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: {{ $.Values.stan.auth.secretRef.externalSecret.secretStore }}
+  target:
+    name: {{ $secretName }}
+    creationPolicy: Owner
+  data:
+  - secretKey: {{ $.Values.stan.auth.secretRef.usernameKey }}
+    remoteRef:
+      key: {{ $.Values.stan.auth.secretRef.externalSecret.remoteUsernameRef }}
+  - secretKey: {{ $.Values.stan.auth.secretRef.passwordKey }}
+    remoteRef:
+      key: {{ $.Values.stan.auth.secretRef.externalSecret.remotePasswordRef }}
+{{- end }}

--- a/charts/nats-streaming/templates/initdb.yaml
+++ b/charts/nats-streaming/templates/initdb.yaml
@@ -1,0 +1,47 @@
+---
+{{- if eq .Values.store.type "sql" }}
+{{- if .Values.store.sql.initdb.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: '{{ .Release.Name }}-init-db'
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  template:
+    metadata:
+      {{- with .Values.store.sql.initdb.annotations }}
+      annotations:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+    spec:
+      terminationGracePeriodSeconds: 0
+      restartPolicy: Never
+      {{- if eq .Values.store.sql.driver "postgres" }}
+      containers:
+        - name: init-database
+          image: {{ .Values.store.sql.initdb.image }}
+          env:
+          - name: PGPASSWORD
+            value: {{ .Values.store.sql.dbPassword }}
+          command: ['psql']
+          args: [
+          '--host', '{{ .Values.store.sql.dbHost }}',
+          '-U', '{{ .Values.store.sql.dbUser }}',
+          '-d', '{{ .Values.store.sql.dbName }}',
+          '-p', '{{ .Values.store.sql.dbPort }}',
+          '-c', 'CREATE TABLE IF NOT EXISTS ServerInfo (uniquerow INTEGER DEFAULT 1, id VARCHAR(1024), proto BYTEA, version INTEGER, PRIMARY KEY (uniquerow));
+          CREATE TABLE IF NOT EXISTS Clients (id VARCHAR(1024), hbinbox TEXT, PRIMARY KEY (id));
+          CREATE TABLE IF NOT EXISTS Channels (id INTEGER, name VARCHAR(1024) NOT NULL, maxseq BIGINT DEFAULT 0, maxmsgs INTEGER DEFAULT 0, maxbytes BIGINT DEFAULT 0, maxage BIGINT DEFAULT 0, deleted BOOL DEFAULT FALSE, PRIMARY KEY (id));
+          CREATE INDEX IF NOT EXISTS Idx_ChannelsName ON Channels (name(256));
+          CREATE TABLE IF NOT EXISTS Messages (id INTEGER, seq BIGINT, timestamp BIGINT, size INTEGER, data BYTEA, CONSTRAINT PK_MsgKey PRIMARY KEY(id, seq));
+          CREATE INDEX IF NOT EXISTS Idx_MsgsTimestamp ON Messages (timestamp);
+          CREATE TABLE IF NOT EXISTS Subscriptions (id INTEGER, subid BIGINT, lastsent BIGINT DEFAULT 0, proto BYTEA, deleted BOOL DEFAULT FALSE, CONSTRAINT PK_SubKey PRIMARY KEY(id, subid));
+          CREATE TABLE IF NOT EXISTS SubsPending (subid BIGINT, row BIGINT, seq BIGINT DEFAULT 0, lastsent BIGINT DEFAULT 0, pending BYTEA, acks BYTEA, CONSTRAINT PK_MsgPendingKey PRIMARY KEY(subid, row));
+          CREATE INDEX IF NOT EXISTS Idx_SubsPendingSeq ON SubsPending (seq);
+          CREATE TABLE IF NOT EXISTS StoreLock (id VARCHAR(30), tick BIGINT DEFAULT 0);
+          ALTER TABLE Clients ADD IF NOT EXISTS proto BYTEA;'
+          ]
+     {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/nats-streaming/templates/nats-configmap.yaml
+++ b/charts/nats-streaming/templates/nats-configmap.yaml
@@ -1,0 +1,180 @@
+{{- define "nats-configmap" }}
+# PID file shared with configuration reloader.
+pid_file: "/var/run/stan/stan.pid"
+
+###############
+#             #
+# Monitoring  #
+#             #
+###############
+http: 8222
+server_name: $POD_NAME
+
+{{- if .Values.cluster.enabled }}
+{{- if or .Values.store.cluster.enabled .Values.store.ft.group }}
+
+###################################
+#                                 #
+# NATS Full Mesh Clustering Setup #
+#                                 #
+###################################
+cluster {
+  port: 6222
+
+  {{- with .Values.cluster.name }}
+  name: {{ . }}
+  {{- end }}
+
+  {{- with .Values.cluster.tls }}
+  {{ $secretName := .secret.name }}
+  tls {
+     {{- with .cert }}
+     cert_file: /etc/nats-certs/cluster/{{ $secretName }}/{{ . }}
+     {{- end }}
+
+     {{- with .key }}
+     key_file: /etc/nats-certs/cluster/{{ $secretName }}/{{ . }}
+     {{- end }}
+
+     {{- with .ca }}
+     ca_file: /etc/nats-certs/cluster/{{ $secretName }}/{{ . }}
+     {{- end }}
+
+     {{- with .insecure }}
+     insecure: {{ . }}
+     {{- end }}
+
+     {{- with .verify }}
+     verify: {{ . }}
+     {{- end }}
+
+     {{- with .verifyAndMap }}
+     verify_and_map: {{ . }}
+     {{- end }}
+
+     {{- with .curvePreferences }}
+     curve_preferences: {{ . }}
+     {{- end }}
+
+     {{- with .timeout }}
+     timeout: {{ . }}
+     {{- end }}
+  }
+  {{- end }}
+
+  routes = [
+    {{ template "nats.clusterRoutes" . }}
+  ]
+  cluster_advertise: $CLUSTER_ADVERTISE
+
+  {{- with .Values.cluster.noAdvertise }}
+  no_advertise: {{ . }}
+  {{- end }}
+
+  connect_retries: {{ .Values.nats.connectRetries }}
+}
+{{- end }}
+{{- end }}
+
+{{- if and .Values.nats.advertise .Values.nats.externalAccess }}
+include "advertise/client_advertise.conf"
+{{- end }}
+
+
+{{- with .Values.nats.logging.debug }}
+debug: {{ . }}
+{{- end }}
+
+{{- with .Values.nats.logging.trace }}
+trace:  {{ . }}
+{{- end }}
+
+{{- with .Values.nats.logging.logtime }}
+logtime: {{ . }}
+{{- end }}
+
+{{- with .Values.nats.logging.connectErrorReports }}
+connect_error_reports: {{ . }}
+{{- end }}
+
+{{- with .Values.nats.logging.reconnectErrorReports }}
+reconnect_error_reports: {{ . }}
+{{- end }}
+
+{{- with .Values.nats.limits.maxConnections }}
+max_connections: {{ . }}
+{{- end }}
+{{- with .Values.nats.limits.maxSubscriptions }}
+max_subscriptions: {{ . }}
+{{- end }}
+{{- with .Values.nats.limits.maxPending }}
+max_pending: {{ . }}
+{{- end }}
+{{- with .Values.nats.limits.maxControlLine }}
+max_control_line: {{ . }}
+{{- end }}
+{{- with .Values.nats.limits.maxPayload }}
+max_payload: {{ . }}
+{{- end }}
+{{- with .Values.nats.pingInterval }}
+ping_interval: {{ . }}
+{{- end }}
+{{- with .Values.nats.maxPings }}
+ping_max: {{ . }}
+{{- end }}
+{{- with .Values.nats.writeDeadline }}
+write_deadline: {{ . | quote }}
+{{- end }}
+{{- with .Values.nats.writeDeadline }}
+lame_duck_duration:  {{ . | quote }}
+{{- end }}
+
+{{- if .Values.auth.enabled }}
+##################
+#                #
+# Authorization  #
+#                #
+##################
+{{- if .Values.auth.resolver }}
+
+{{- if eq .Values.auth.resolver.type "memory" }}
+resolver: MEMORY
+include "accounts/{{ .Values.auth.resolver.configMap.key }}"
+{{- end }}
+
+{{- if eq .Values.auth.resolver.type "URL" }}
+{{- with .Values.auth.resolver.url }}
+resolver: URL({{ . }})
+{{- end }}
+operator: /etc/nats-config/operator/{{ .Values.auth.operatorjwt.configMap.key }}
+{{- end }}
+
+{{- end }}
+
+{{- with .Values.auth.systemAccount }}
+system_account: {{ . }}
+{{- end }}
+
+{{- with .Values.auth.basic }}
+
+{{- with .noAuthUser }}
+no_auth_user: {{ . }}
+{{- end }}
+
+{{- with .users }}
+authorization {
+  users: [
+  {{- range . }}
+    {{- toRawJson . | nindent 4 }},
+  {{- end }}
+  ]
+}
+{{- end }}
+
+{{- with .accounts }}
+accounts: {{- toRawJson . }}
+{{- end }}
+{{- end }}
+
+{{- end }}
+{{- end }}

--- a/charts/nats-streaming/templates/nodePort.yaml
+++ b/charts/nats-streaming/templates/nodePort.yaml
@@ -1,0 +1,19 @@
+---
+{{- if $.Values.nodePort.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "stan.name" . }}-nodeport
+  labels:
+    app: {{ template "stan.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  type: NodePort
+  selector:
+    app: {{ template "stan.name" . }}
+  ports:
+    - nodePort: {{ $.Values.nodePort.nodePort}}
+      port: 4222
+      protocol: TCP
+      targetPort: 4222
+{{- end }}

--- a/charts/nats-streaming/templates/nodePort.yaml
+++ b/charts/nats-streaming/templates/nodePort.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if $.Values.nodePort.enable }}
+{{- if $.Values.nodePort.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/nats-streaming/templates/pvc.yaml
+++ b/charts/nats-streaming/templates/pvc.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.store.volume.persistentVolumeClaim -}}{{- if not .Values.store.volume.persistentVolumeClaim.existingClaim -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "stan.name" . }}-pvc
+  labels:
+    app: {{ template "stan.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  {{- with .Values.store.volume.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  accessModes:
+  {{- with .Values.store.volume.accessModes }}
+  - {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.store.volume.storageSize }}
+{{- end -}}{{- end -}}

--- a/charts/nats-streaming/templates/service.yaml
+++ b/charts/nats-streaming/templates/service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "stan.name" . }}
+  labels:
+    app: {{ template "stan.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  selector:
+    app: {{ template "stan.name" . }}
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 7777
+  - name: monitor
+    port: 8222
+  - name: client
+    port: 4222
+    appProtocol: tcp

--- a/charts/nats-streaming/templates/serviceMonitor.yaml
+++ b/charts/nats-streaming/templates/serviceMonitor.yaml
@@ -1,0 +1,37 @@
+{{ if and .Values.exporter.enabled .Values.exporter.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "stan.name" . }}
+  {{- if .Values.exporter.serviceMonitor.namespace }}
+  namespace: {{ .Values.exporter.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ $.Values.kubernetesNamespace | quote }}
+  {{- end }}
+  {{- if .Values.exporter.serviceMonitor.labels }}
+  labels:
+    {{- toYaml .Values.exporter.serviceMonitor.labels | nindent 4 }}
+  {{- end }}
+  {{- if .Values.exporter.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml .Values.exporter.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - port: metrics
+  {{- if .Values.exporter.serviceMonitor.path }}
+    path: {{ .Values.exporter.serviceMonitor.path }}
+  {{- end }}
+  {{- if .Values.exporter.serviceMonitor.interval }}
+    interval: {{ .Values.exporter.serviceMonitor.interval }}
+  {{- end }}
+  {{- if .Values.exporter.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.exporter.serviceMonitor.scrapeTimeout }}
+  {{- end }}
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: {{ template "stan.name" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}

--- a/charts/nats-streaming/templates/statefulset.yaml
+++ b/charts/nats-streaming/templates/statefulset.yaml
@@ -1,0 +1,268 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "stan.name" . }}
+  labels:
+    app: {{ template "stan.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "stan.name" . }}
+
+  replicas: {{ include "stan.replicaCount" .  | required ".Values.stan.replicas should be greater or equal to 3 in clustered mode" }}
+
+  # NATS Streaming service name
+  serviceName: {{ template "stan.name" . }}
+
+  template:
+    metadata:
+      {{- if or .Values.podAnnotations .Values.exporter.enabled }}
+      annotations:
+        {{- if .Values.exporter.enabled }}
+        prometheus.io/path: /metrics
+        prometheus.io/port: "7777"
+        prometheus.io/scrape: "true"
+        {{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels:
+        app: {{ template "stan.name" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{ toYaml . | indent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: {{ template "stan.name".  }}-config
+          defaultMode: 0755
+        name: config-volume
+
+      {{- if .Values.store.volume.enabled }}
+        {{- if .Values.store.volume.persistentVolumeClaim }}
+      - name: {{ template "stan.name" . }}-pvc
+        persistentVolumeClaim:
+          {{- if not .Values.store.volume.persistentVolumeClaim.existingClaim }}
+          claimName: {{ template "stan.name" . }}-pvc
+          {{ else }}
+          claimName: {{ .Values.store.volume.persistentVolumeClaim.claimName }}
+          {{ end }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.stan.credentials }}
+      - name: stan-sys-creds
+        secret:
+          secretName: {{ .Values.stan.credentials.secret.name }}
+      {{- end }}
+      {{- if .Values.stan.auth.nkeySeedFile }}
+      - name: stan-sys-nkey-seed-file
+        secret:
+          secretName: {{ .Values.stan.auth.nkeySeedFile.secret.name }}
+      {{- end }}
+
+      # Local volume shared with the reloader.
+      - name: pid
+        emptyDir: {}
+
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ template "stan.name" . }}
+            topologyKey: kubernetes.io/hostname
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range .Values.topologySpreadConstraints }}
+        {{- if and .maxSkew .topologyKey }}
+      - maxSkew: {{ .maxSkew }}
+        topologyKey: {{ .topologyKey }}
+        {{- if .whenUnsatisfiable }}
+        whenUnsatisfiable: {{ .whenUnsatisfiable }}
+        {{- end }}
+        labelSelector:
+          matchLabels:
+            app: {{ template "stan.name" $ }}
+            chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+      containers:
+        ####################
+        #  NATS Streaming  #
+        ####################
+        - name: stan
+          image: {{ .Values.stan.image }}
+          {{- if .Values.stan.securityContext }}
+          securityContext:
+            {{- toYaml .Values.stan.securityContext | nindent 12 }}
+          {{- end }}
+          args:
+          - -sc
+          - /etc/stan-config/stan.conf
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          {{- if and .Values.stan.auth.enabled .Values.stan.auth.secretRef }}
+          # These environment variables are loaded in the config map. See configmap.yaml
+          # All undefined variable references in the configuration file will be resolved from environment variable if possible. 
+          - name: AUTH_USER
+            valueFrom:
+              secretKeyRef: 
+                name: {{ .Values.stan.auth.secretRef.secret }}
+                key: {{ .Values.stan.auth.secretRef.usernameKey}}
+          - name: AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef: 
+                name: {{ .Values.stan.auth.secretRef.secret }}
+                key: {{ .Values.stan.auth.secretRef.passwordKey}}
+          {{- end }} 
+          - name: CLUSTER_ADVERTISE
+            value: {{ template "nats.clusterAdvertise" . }}
+          - name: STAN_SERVICE_NAME
+            value: {{ template "stan.name" . }}
+          - name: STAN_REPLICAS
+            value: "{{ .Values.stan.replicas }}"
+          ports:
+          - containerPort: 8222
+            name: monitor
+          - containerPort: 7777
+            name: metrics
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- if and .Values.store.cluster.enabled .Values.clusterReadinessProbe.enabled }}
+          {{- with .Values.clusterReadinessProbe.probe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          {{- with .Values.livenessProbe.probe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/stan-config
+          {{- if eq .Values.store.type "file" }}
+          {{- if .Values.store.volume.enabled }}
+          - name: {{ template "stan.name" . }}-pvc
+            mountPath: {{ .Values.store.volume.mount }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.stan.credentials }}
+          - name: stan-sys-creds
+            mountPath: /etc/stan-creds
+          {{- end }}
+          {{- if .Values.stan.auth.nkeySeedFile }}
+          - name: stan-sys-nkey-seed-file
+            mountPath: /etc/nkey-seed-file
+            subPath: {{ .Values.stan.auth.nkeySeedFile.secret.key }}
+          {{- end }}
+          - name: pid
+            mountPath: /var/run/stan
+
+        {{- if .Values.exporter.enabled }}
+        #################################
+        #                               #
+        #  NATS Prometheus Exporter     #
+        #                               #
+        #################################
+        - name: metrics
+          image: {{ .Values.exporter.image }}
+          {{- if .Values.exporter.securityContext }}
+          securityContext:
+            {{- toYaml .Values.exporter.securityContext | nindent 12 }}
+          {{- end }}
+          args:
+          {{- if .Values.exporter.args }}
+          {{- toYaml .Values.exporter.args | nindent 10 }}
+          {{- else }}
+          - -connz
+          - -routez
+          - -subz
+          - -varz
+          - -channelz
+          - -serverz
+          - http://localhost:8222/
+          {{- end }}
+          ports:
+          - containerPort: 7777
+            name: metrics
+          {{- with .Values.exporter.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+
+        {{- if .Values.reloader.enabled }}
+        #################################
+        #                               #
+        #  NATS Configuration Reloader  #
+        #                               #
+        #################################
+        - name: reloader
+          image: {{ .Values.reloader.image }}
+          imagePullPolicy: {{ .Values.reloader.pullPolicy }}
+          command:
+           - "nats-server-config-reloader"
+           - "-pid"
+           - "/var/run/stan/stan.pid"
+           - "-config"
+           - "/etc/stan-config/stan.conf"
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/stan-config
+            - name: pid
+              mountPath: /var/run/stan
+        {{- end }}
+
+  {{- if eq .Values.store.type "file" }}
+  {{- if .Values.store.volume.enabled }}
+  {{- if not .Values.store.volume.persistentVolumeClaim }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "stan.name" . }}-pvc
+    spec:
+      {{- with .Values.store.volume.storageClass }}
+      storageClassName: {{ . }}
+      {{- end }}
+      accessModes:
+      {{- with .Values.store.volume.accessModes }}
+      - {{ . }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.store.volume.storageSize }}
+  {{- end }}
+  {{- end }}
+  {{- end }}

--- a/charts/nats-streaming/templates/validation-checks.yaml
+++ b/charts/nats-streaming/templates/validation-checks.yaml
@@ -1,0 +1,37 @@
+ {{- if (not ($.Values.kubernetesNamespace)) }}
+    {{- fail "namespace must be set for cluster service DNS lookup to work correctly." }}
+ {{- end }}
+
+{{- if $.Values.nodePort.enable }}
+ {{- if not $.Values.nodePort.nodePort }}
+    {{- fail "nodePort.nodePort must be set if nodePort.enable has been set to true" }}
+ {{- end }}
+
+   {{- if or (lt (int $.Values.nodePort.nodePort) (int 30000)) (gt (int $.Values.nodePort.nodePort) (int 32767)) }}
+      {{- fail (printf "specified port %d is outside of the cluster's node port range (30000-32767)" $.Values.nodePort.nodePort) }}
+   {{- end }}
+{{- end }}
+
+{{- if and $.Values.stan.auth.enabled }}
+   {{- if not $.Values.stan.auth.secretRef.secret }}
+      {{- fail "stan.auth.secret must be set if stan.auth is enabled." }}
+   {{- end }}
+
+   {{- if not $.Values.stan.auth.secretRef.usernameKey}}
+      {{- fail "stan.auth.usernameKey must be set if stan.auth is enabled." }}
+   {{- end }}
+
+   {{- if not $.Values.stan.auth.secretRef.passwordKey}}
+      {{- fail "stan.auth.passwordKey must be set if stan.auth is enabled." }}
+   {{- end }}
+
+   {{- if $.Values.stan.auth.secretRef.externalSecret.enable}}
+      {{- if not $.Values.stan.auth.secretRef.externalSecret.remoteUsernameRef }}
+         {{- fail "stan.auth.secretRef.externalSecret.remoteUsernameRef must be set if externalSecret has been enabled" }}
+      {{- end }}
+
+      {{- if not $.Values.stan.auth.secretRef.externalSecret.remotePasswordRef}}
+         {{- fail "stan.auth.secretRef.externalSecret.remotePasswordRef must be set if externalSecret has been enabled" }}
+      {{- end }}
+   {{- end }}
+{{- end }}

--- a/charts/nats-streaming/templates/validation-checks.yaml
+++ b/charts/nats-streaming/templates/validation-checks.yaml
@@ -2,9 +2,9 @@
     {{- fail "namespace must be set for cluster service DNS lookup to work correctly." }}
  {{- end }}
 
-{{- if $.Values.nodePort.enable }}
+{{- if $.Values.nodePort.enabled }}
  {{- if not $.Values.nodePort.nodePort }}
-    {{- fail "nodePort.nodePort must be set if nodePort.enable has been set to true" }}
+    {{- fail "nodePort.nodePort must be set if nodePort.enabled has been set to true" }}
  {{- end }}
 
    {{- if or (lt (int $.Values.nodePort.nodePort) (int 30000)) (gt (int $.Values.nodePort.nodePort) (int 32767)) }}

--- a/charts/nats-streaming/templates/validation-checks.yaml
+++ b/charts/nats-streaming/templates/validation-checks.yaml
@@ -25,7 +25,7 @@
       {{- fail "stan.auth.passwordKey must be set if stan.auth is enabled." }}
    {{- end }}
 
-   {{- if $.Values.stan.auth.secretRef.externalSecret.enable}}
+   {{- if $.Values.stan.auth.secretRef.externalSecret.enabled }}
       {{- if not $.Values.stan.auth.secretRef.externalSecret.remoteUsernameRef }}
          {{- fail "stan.auth.secretRef.externalSecret.remoteUsernameRef must be set if externalSecret has been enabled" }}
       {{- end }}

--- a/charts/nats-streaming/tests/externalsecret_test.yaml
+++ b/charts/nats-streaming/tests/externalsecret_test.yaml
@@ -1,0 +1,41 @@
+suite: Validation check tests
+templates:
+  - externalsecret.yaml
+tests:
+  - it: "Should render correct ExternalSecret"
+    set:
+      kubernetesNamespace: test
+      stan.auth.enabled: true
+      stan.auth.secretRef.secret: "mysecret"
+      stan.auth.secretRef.usernameKey: "user"
+      stan.auth.secretRef.passwordKey: "password"
+      stan.auth.secretRef.externalSecret.enabled: true
+      stan.auth.secretRef.externalSecret.remoteUsernameRef: "mysecret__user"
+      stan.auth.secretRef.externalSecret.remotePasswordRef: "mysecret__password"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: "metadata.name"
+          value: "mysecret"
+      - equal:
+          path: "spec.secretStoreRef.kind"
+          value: "SecretStore"
+      - equal:
+          path: "spec.secretStoreRef.name"
+          value: "google-secret-manager"
+      - equal:
+          path: "spec.target.name"
+          value: "mysecret"
+      - contains:
+          path: "spec.data"
+          content:
+            secretKey: "user"
+            remoteRef: 
+              key: "mysecret__user"
+      - contains:
+          path: "spec.data"
+          content:
+            secretKey: "password"
+            remoteRef: 
+              key: "mysecret__password"

--- a/charts/nats-streaming/tests/validation-checks_test.yaml
+++ b/charts/nats-streaming/tests/validation-checks_test.yaml
@@ -1,0 +1,86 @@
+suite: Validation check tests
+tests: 
+  - it: "Should fail if kubernetesNamespace has not been set"
+    set: 
+      kubernetesNamespace: null
+    asserts:
+      - failedTemplate: {}
+
+  - it: "Should not fail if kubernetesNamespace has been set"
+    set: 
+      kubernetesNamespace: "test"
+    asserts:
+      - notFailedTemplate: {}
+  
+  - it: "Should fail if stan.auth is enabled, but no secretRef has been set"
+    set:
+      kubernetesNamespace: "test"
+      stan.auth.enabled: true
+      stan.auth.secretRef.secret: ""
+      stan.auth.secretRef.usernameKey: user
+      stan.auth.secretRef.passwordKey: user
+    asserts:
+      - failedTemplate: {}
+          
+
+  - it: "Should not fail if stan.auth is enabled and secretRef has been set"
+    set:
+      kubernetesNamespace: "test"
+      stan.auth.enabled: true
+      stan.auth.secretRef.secret: "test"
+      stan.auth.secretRef.usernameKey: user
+      stan.auth.secretRef.passwordKey: user
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: "Should fail if stan.auth is enabled, but usernameKey is not set"
+    set:
+      kubernetesNamespace: "test"
+      stan.auth.enabled: true
+      stan.auth.secretRef.secret: "test"
+      stan.auth.secretRef.usernameKey: ""
+      stan.auth.secretRef.passwordKey: user
+    asserts:
+      - failedTemplate: {}
+
+  - it: "Should fail if stan.auth is enabled, but passwordKey is not set"
+    set:
+      kubernetesNamespace: "test"
+      stan.auth.enabled: true
+      stan.auth.secretRef.secret: "test"
+      stan.auth.secretRef.usernameKey: "user"
+      stan.auth.secretRef.passwordKey: "" 
+    asserts:
+      - failedTemplate: {}
+
+  - it: "Should fail if nodePort is enabled, but nodePort is below range"
+    set:
+      kubernetesNamespace: "test"
+      nodePort.enabled: true
+      nodePort.nodePort: 29999
+    asserts:
+      - failedTemplate: {}
+
+  - it: "Should fail if nodePort is enabled, but nodePort is above range"
+    set:
+      kubernetesNamespace: "test"
+      nodePort.enabled: true
+      nodePort.nodePort: 32768
+    asserts:
+      - failedTemplate: {}
+
+  - it: "Should not fail if nodePort is enabled, if nodePort is within range"
+    set:
+      kubernetesNamespace: "test"
+      nodePort.enabled: true
+      nodePort.nodePort: 30000
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: "Should not fail if nodePort is enabled, if nodePort is within range"
+    set:
+      kubernetesNamespace: "test"
+      nodePort.enabled: true
+      nodePort.nodePort: 32767
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/nats-streaming/values.yaml
+++ b/charts/nats-streaming/values.yaml
@@ -32,7 +32,7 @@ stan:
       passwordKey:
       # Create ExternalSecret manifest that synchronises credentials from e.g. Google Secret Manager.
       externalSecret:
-        enable: false
+        enabled: false
         secretStore: google-secret-manager
         remoteUsernameRef:
         remotePasswordRef:

--- a/charts/nats-streaming/values.yaml
+++ b/charts/nats-streaming/values.yaml
@@ -1,0 +1,310 @@
+kubernetesNamespace:  
+nameOverride: ""
+imagePullSecrets: []
+##################################
+#                                #
+#  NATS Streaming Configuration  #
+#                                #
+##################################
+stan:
+  image: nats-streaming:0.25.6
+  pullPolicy: IfNotPresent
+  replicas: 3
+
+  # securityContext for the stan container
+  securityContext: {}
+
+
+  # Cluster name, generated into a name from the
+  # release name by default.
+  clusterID:
+
+  logging:
+    debug: true
+    trace:
+
+  auth:
+    enabled: false
+
+    secretRef:
+      secret: 
+      usernameKey: 
+      passwordKey:
+      # Create ExternalSecret manifest that synchronises credentials from e.g. Google Secret Manager.
+      externalSecret:
+        enable: false
+        secretStore: google-secret-manager
+        remoteUsernameRef:
+        remotePasswordRef:
+
+serviceAccountName: ""
+
+# Annotations to add to the NATS pods
+# ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+
+# Toggle whether to use setup a Pod Security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext: null
+# securityContext:
+#   fsGroup: 1000
+#   runAsUser: 1000
+#   runAsNonRoot: true
+
+# Pod Topology Spread Constraints
+# ref https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+# - maxSkew: 1
+#   topologyKey: zone
+#   whenUnsatisfiable: DoNotSchedule
+
+# Resource requests and limits for primary stan container
+# ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+resources: {}
+
+# Readiness probe to determine when nats-streaming is ready
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+readinessProbe:
+  httpGet:
+    path: /streaming/serverz
+    port: monitor
+  timeoutSeconds: 2
+
+# Readiness probe to determine when nats-streaming cluster is ready.
+# Overrides the readinessProbe in case present.
+# NOTE: Only works with the nats-streaming alpine image.
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+clusterReadinessProbe:
+  enabled: false
+  probe:
+    exec:
+      command: ["/bin/sh", "-c", "n=$(($STAN_REPLICAS-1)); for i in `seq 0 $n`; do wget -qO- $STAN_SERVICE_NAME-$i.$STAN_SERVICE_NAME:8222/streaming/serverz 2> /dev/null > /dev/null; done; if [[ $? -ne 0 ]]; then wget -qO- 127.0.0.1:8222/streaming/serverz | grep role | awk '{print $2}' | grep '\\(Candidate\\|Follower\\|Leader\\)'; else wget -qO- 127.0.0.1:8222/streaming/serverz | grep role | awk '{print $2}' | grep '\\(Follower\\|Leader\\)'; fi;"]
+    initialDelaySeconds:
+    periodSeconds: 10
+
+# Liveness probe to determine when nats-streaming is alive
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  enabled: false
+  probe:
+    httpGet:
+      path: /
+      port: monitor
+    timeoutSeconds: 2
+
+############################
+#                          #
+#  NodePort configuration  #
+#                          #
+############################
+nodePort: 
+ # Enable the NodePort service definition.
+  enable: false
+
+  # Port that will be exposed.
+  nodePort: 
+  
+
+###########################
+#                         #
+#  Storage configuration  #
+#                         #
+###########################
+store:
+  # We only support file for on-prem migration
+  type: file
+
+  #
+  # Fault tolerance group
+  #
+  ft:
+    group:
+
+  # Configures streaming/store_limits.
+  #
+  # NOTE: Section in snake case since they will become
+  # the same objects.
+  #
+  # Look at the NATS Streaming configuration for this:
+  #
+  # https://docs.nats.io/nats-streaming-server/configuring/cfgfile#store-limits-configuration
+  #
+  limits: {}
+
+  # Enables streaming/partitioning
+  #
+  # https://docs.nats.io/nats-streaming-concepts/partitioning
+  #
+  partitioning:
+    enabled: false
+
+  #
+  # Volume claim configuration. Required if the store type is `file` or if
+  # cluster is enabled.
+  #
+  volume:
+    enabled: true
+    mount: /data/stan
+    storageSize: 5Gi
+    accessModes: ReadWriteMany
+    storageClass: nfs-client
+
+  #
+  # File storage settings.
+  #
+  file:
+    path: /data/stan/store
+    # Configures streaming/file_options as is.
+    #
+    # NOTE: Section in snake case since they will become
+    # the same objects.
+    #
+    # Look at the NATS Streaming configuration for this:
+    #
+    # https://docs.nats.io/nats-streaming-server/configuring/cfgfile#file-options-configuration
+    #
+    options: {}
+
+  # In case of using file storage, sets up a 3 node cluster.
+  cluster:
+    enabled: true
+    logPath: /data/stan/log
+
+
+#######################################
+#                                     #
+# Prometheus Exporter configuration   #
+#                                     #
+#######################################
+exporter:
+  enabled: true
+  image: natsio/prometheus-nats-exporter:latest
+  pullPolicy: IfNotPresent
+  securityContext: {}
+  resources: {}
+  # override the default args passed to the exporter
+  # see https://github.com/nats-io/prometheus-nats-exporter#usage
+  # make sure to pass HTTP monitoring port URL as last arg, e.g ["-connz", "http://localhost:8222/"]
+  args: []
+  # Prometheus operator ServiceMonitor support. Exporter has to be enabled
+  serviceMonitor:
+    enabled: false
+    ## Specify the namespace where Prometheus Operator is running
+    ##
+    # namespace: monitoring
+    labels: {}
+    annotations: {}
+    path: /metrics
+    # interval:
+    # scrapeTimeout:
+
+#
+#  Embedded NATS Configuration
+#
+#  NOTE: Should be kept in sync with the NATS Helm Chart as well.
+#
+#################################################################################
+#                                                                               #
+#  _   _    _  _____ ____    _____           _              _     _          _  #
+# | \ | |  / \|_   _/ ___|  | ____|_ __ ___ | |__   ___  __| | __| | ___  __| | #
+# |  \| | / _ \ | | \___ \  |  _| | '_ ` _ \| '_ \ / _ \/ _` |/ _` |/ _ \/ _` | #
+# | |\  |/ ___ \| |  ___) | | |___| | | | | | |_) |  __/ (_| | (_| |  __/ (_| | #
+# |_| \_/_/   \_\_| |____/  |_____|_| |_| |_|_.__/ \___|\__,_|\__,_|\___|\__,_| #
+#                                                                               #
+#################################################################################
+nats:
+  pullPolicy: IfNotPresent
+
+  # Toggle whether to enable external access.
+  # This binds a host port for clients, gateways and leafnodes.
+  externalAccess: false
+
+  # Toggle to disable client advertisements (connect_urls),
+  # in case of running behind a load balancer
+  # it might be required to disable advertisements.
+  advertise: true
+
+  # The number of connect attempts against discovered routes.
+  connectRetries: 30
+
+  # How many seconds should pass before sending a PING
+  # to a client that has no activity.
+  pingInterval:
+
+  # Server settings.
+  limits:
+    maxConnections:
+    maxSubscriptions:
+    maxControlLine:
+    maxPayload:
+
+    writeDeadline:
+    maxPending:
+    maxPings:
+    lameDuckDuration:
+
+  logging:
+    debug: true
+    trace:
+    logtime: true 
+    connectErrorReports:
+    reconnectErrorReports:
+
+cluster:
+  # NOTE: NATS Server service is enabled by default, but will get disabled
+  # if a NATS url is defined.
+  enabled: true
+
+  # NOTE: Recommended to enable if running behind a load balancer.
+  noAdvertise: true
+
+
+# In case of both external access and advertisements being
+# enabled, an initializer container will be used to gather
+# the public ips.
+bootconfig:
+  image: natsio/nats-boot-config:0.5.4
+  pullPolicy: IfNotPresent
+
+# The NATS config reloader image to use.
+reloader:
+  enabled: false
+  image: natsio/nats-server-config-reloader:0.6.2
+  pullPolicy: IfNotPresent
+  securityContext: {}
+
+# Authentication setup
+auth:
+  enabled: false
+
+  # Reference to the Operator JWT.
+  # operatorjwt:
+  #   configMap:
+  #     name: operator-jwt
+  #     key: KO.jwt
+
+  # Public key of the System Account
+  # systemAccount:
+
+  # resolver:
+  #   ############################
+  #   #                          #
+  #   # Memory resolver settings #
+  #   #                          #
+  #   ##############################
+  #   # type: memory
+  #   #
+  #   # Use a configmap reference which will be mounted
+  #   # into the container.
+  #   #
+  #   # configMap:
+  #   #   name: nats-accounts
+  #   #   key: resolver.conf
+  #
+  #   ##########################
+  #   #                        #
+  #   #  URL resolver settings #
+  #   #                        #
+  #   ##########################
+  #   # type: URL
+  #   # url: "http://nats-account-server:9090/jwt/v1/accounts/"


### PR DESCRIPTION
Quick overview over changes that deviate from the "stan" chart that this chart is a fork of (https://github.com/nats-io/k8s/tree/main/helm/charts/stan) 

## New properties
Adds the following new properties: 
- `kubernetesNamespace`
- `stan.auth.secretRef`
- `nodePort`

The `kubernetesNamespace` property is added because it is required for the internal DNS routing to work in `nats-configmap.yaml`. `nats.clusterRoutes` is defined in `helpers.tpl`. The cluster nodes were not able to connect to its peers in the cluster without this property. 

The `stan.auth.secretRef` enables specifying of auth credentials through a secret. Originally the chart only supported specifying the credentials through clear text in the `values.yaml` file. This feature also supports creation of an `ExternalSecret` object. 

The `nodePort` property enables creation of a `Service` object with kind `NodePort`. It is used for exposing the NATS instance to outside of the cluster, e.g. to G4 Kunde. 

## Changes to default values
This fork also introduces defaults that are specific to the Gen 2 on-prem cluster setup. Examples include: 
- default `store.type` to `file`
  - We only support persistance through PVCs 
- default `store.volume.storageClass` to our deployed nfs provisioner: `nfs-client`
- default `store.volume.accessMode` to `ReadWriteMany` 
  - Matches legacy cluster setup 
- default `nats.cluster.enabled` to `true`. 
  - Most NATS instanes are deployed in Cluster mode
- default `nats.cluster.noAdvertise` to `true`
  - I noticed an issue where the NATS instance in the "ansoegning" namespace would try to connect to the NATS instance in the "cardservice" namespace. This was suspected to be caused by `cluster_advertise` set to `true`. Enabling noAdvertise disables the `cluster_advertise` setting. 
 
## Other changes
This fork also trims off many configuration options from `values.yaml` to reduce complexity of the chart. 