### PR TITLE
(fix) db-migration: Fix image pull secrets

### DIFF
--- a/charts/db-migration/Chart.yaml
+++ b/charts/db-migration/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: db-migration
 description: A Helm chart for a running a DB migration.
-version: 1.1.0
+version: 1.1.1

--- a/charts/db-migration/templates/job.yaml
+++ b/charts/db-migration/templates/job.yaml
@@ -37,7 +37,9 @@ spec:
     spec:
       {{- if .imagePullSecrets }}
       imagePullSecrets:
-        {{- .imagePullSecrets | toYaml | nindent 8 }}
+        {{- range $secret := .imagePullSecrets }}
+        - name: {{ $secret }}
+        {{- end }}
       {{- end }}
       restartPolicy: {{ .restartPolicy }}
       shareProcessNamespace: {{ .shareProcessNamespace | default "false" }}

--- a/charts/db-migration/tests/job_test.yaml
+++ b/charts/db-migration/tests/job_test.yaml
@@ -1,0 +1,16 @@
+suite: job tests
+templates:
+  - job.yaml
+tests:
+  - it: "Should render secrets correctly"
+    set:
+      job.imagePullSecrets: ["secret-1", "secret-2"]
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: "secret-1"
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: "secret-2"


### PR DESCRIPTION
Fixed  bug where following the comments in the `values.yaml` file for `job.imagePullSecrets` would cause a failure, since it does not follow the Kubernetes spec when templated. 