### PR TITLE
db-migration: Rerelease DB Migration 1.1.1

### DIFF
--- a/charts/db-migration/templates/job.yaml
+++ b/charts/db-migration/templates/job.yaml
@@ -2,7 +2,6 @@
 {{- if not (has .Values.job.restartPolicy $types) }}
 {{- fail (printf "job.restartPolicy [%s] does not have a valid type. Valid type: %s" .Values.job.restartPolicy (join ", " $types)) }}
 {{- end }}
-
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Last released failed to publish chart to the gh pages Helm repository for some reason... 