### PR TITLE
Default ingress pjuu

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 2.2.1
+version: 2.3.0

--- a/charts/simple-deployment/README.md
+++ b/charts/simple-deployment/README.md
@@ -131,11 +131,12 @@ ingress:
 **The new ingress in Gen 2 supports three different domains ok.dk, okdc.dk and okcloud.dk**
 
 ### Example 5.1: Gen 2 private by default
+If you want a to deploy a new private service on the okdc.dk domain, you need to specify private as a subdomain.
 
 ```yaml
 ingress:
   enable: true
-  host: example.test.okdc.dk
+  host: example.private.test.okdc.dk
 ```
 
 ### Example 5.2: Gen 2 public

--- a/charts/simple-deployment/README.md
+++ b/charts/simple-deployment/README.md
@@ -8,6 +8,9 @@ Here's a few bullet points on what it's capable of.
 - Mounting secrets, configmaps or additional volumes into the pods.
 - Enabling a service for the deployment.
 - Enabling an ingress with TLS.
+- Private ingress by default in the Gen 2 kubernetes cluster.
+  - This is overwriteable with the boolean "isPrivate", or by setting your specific ingress with ingressClassName in your services' values file.
+- Public ingress by default in the GKE Cloud cluster.
 
 ## Examples 1
 
@@ -123,3 +126,14 @@ ingress:
           number: 3000
 ```
 
+## Example 5
+
+This example shows how to enable public ingress in Gen 2.
+
+```yaml
+ingress:
+    ingress:
+  enable: true
+  host: example.test.okdc.dk
+  isPrivate: false
+```

--- a/charts/simple-deployment/README.md
+++ b/charts/simple-deployment/README.md
@@ -128,10 +128,10 @@ ingress:
 
 ## Example 5
 
-**The new ingress in Gen 2 supports three different domains ok.dk, okdc.dk and okcloud.dk**
+**The new ingress in Gen 2 supports three different domains: ok.dk, okdc.dk and okcloud.dk**
 
 ### Example 5.1: Configuring a private ingress
-If you want to deploy a new service on the ok.dk or okdc.dk domain, and want to expose the ingress privately in ok the following example can be used. In this case 'isPrivate' it set to true.
+If you want to deploy a new service on the ok.dk or okdc.dk domain, and want to expose the ingress privately in OK, the following example can be used. In this case 'isPrivate' is set to true.
 
 ```yaml
 ingress:
@@ -141,7 +141,7 @@ ingress:
 ```
 
 ### Example 5.2: Configuring a public ingress
-If you want to deploy a new service on the ok.dk, okdc.dk or okcloud.dk domain, and want to expose the ingress publicly the following example can be used. In this case 'isPrivate' it set to false.
+If you want to deploy a new service on the ok.dk, okdc.dk or okcloud.dk domain, and want to expose the ingress publicly, the following example can be used. In this case 'isPrivate' is set to false.
 
 ```yaml
 ingress:

--- a/charts/simple-deployment/README.md
+++ b/charts/simple-deployment/README.md
@@ -128,6 +128,17 @@ ingress:
 
 ## Example 5
 
+**The new ingress in Gen 2 supports three different domains ok.dk, okdc.dk and okcloud.dk**
+
+### Example 5.1: Gen 2 private by default
+
+```yaml
+ingress:
+  enable: true
+  host: example.test.okdc.dk
+```
+
+### Example 5.2: Gen 2 public
 This example shows how to enable public ingress in Gen 2.
 
 ```yaml
@@ -135,4 +146,23 @@ ingress:
   enable: true
   host: example.test.okdc.dk
   isPrivate: false
+```
+
+### 5.3: The template will fail in two cases
+
+- If you specify "isPrivate: true" when using okcloud.dk.
+
+```yaml
+ingress:
+  enable: true
+  host: example.test.okcloud.dk
+  isPrivate: true
+```
+
+- If you try to deploy your service using an unsupported domain.
+
+```yaml
+ingress:
+  enable: true
+  host: example.blahblah.com
 ```

--- a/charts/simple-deployment/README.md
+++ b/charts/simple-deployment/README.md
@@ -130,40 +130,67 @@ ingress:
 
 **The new ingress in Gen 2 supports three different domains ok.dk, okdc.dk and okcloud.dk**
 
-### Example 5.1: Gen 2 private by default
-If you want a to deploy a new private service on the okdc.dk domain, you need to specify private as a subdomain.
+### Example 5.1: Configuring a private ingress
+If you want to deploy a new service on the ok.dk or okdc.dk domain, and want to expose the ingress privately in ok the following example can be used. In this case 'isPrivate' it set to true.
 
 ```yaml
 ingress:
   enable: true
   host: example.private.test.okdc.dk
+  isPrivate: true
 ```
 
-### Example 5.2: Gen 2 public
-This example shows how to enable public ingress in Gen 2.
-
-```yaml
-ingress:
-  enable: true
-  host: example.test.okdc.dk
-  isPrivate: false
-```
-
-### 5.3: The template will fail in two cases
-
-- If you specify "isPrivate: true" when using okcloud.dk.
+### Example 5.2: Configuring a public ingress
+If you want to deploy a new service on the ok.dk, okdc.dk or okcloud.dk domain, and want to expose the ingress publicly the following example can be used. In this case 'isPrivate' it set to false.
 
 ```yaml
 ingress:
   enable: true
   host: example.test.okcloud.dk
-  isPrivate: true
+  isPrivate: false
 ```
 
-- If you try to deploy your service using an unsupported domain.
+### 5.3: Using the default privacy of a domain
+If you do NOT specify 'isPrivate' on an ingress controller the domains default will be used instead. Reference the following table for defaults.
+|Domain|Default privacy|
+|---|---|
+|*.ok.dk|private|
+|*.okdc.dk|private|
+|*.okcloud.dk|public|
 
+The below example will result in a private ingress because the host is using the ok.dk domain.
 ```yaml
 ingress:
   enable: true
-  host: example.blahblah.com
+  host: example.test.ok.dk
 ```
+
+The below example will result in a public ingress because the host is using the okcloud.dk domain.
+```yaml
+ingress:
+  enable: true
+  host: example.test.okcloud.dk
+```
+
+### Domains supported by simple-deployment
+Note that if you're using a domain that is not in the following table simple-deployment will throw an error. \
+All possible domain/env combinations are listed below along with the supported ingress privacy. \
+When using the okdc.dk domain one must add private as a subdomain before the environment in order to use 'isPrivate: true'.
+
+| Domain  | Supports Private | Supports Public | Environment|
+| ---| --- | --- | --- |
+|**okdc.dk**||||
+|*.private.test.okdc.dk         |yes  |no   |test|
+|*.private.prod-test.okdc.dk    |yes  |no   |prodtest|
+|*.private.okdc.dk              |yes  |no   |prod|
+|*.test.okdc.dk                 |no   |yes  |test|
+|*.prod-test.okdc.dk            |no   |yes  |prodtest|
+|*.okdc.dk                      |no   |yes  |prod|
+|**ok.dk**||||
+|*.test.ok.dk                   |yes  |yes  |test|
+|*.prod-test.ok.dk              |yes  |yes  |prodtest|
+|*.ok.dk                        |yes  |yes  |prod|
+|**okcloud.dk**||||
+|*.test.okcloud.dk              |no   |yes  |test|
+|*.prod-test.okcloud.dk         |no   |yes  |prodtest|
+|*.okcloud.dk                   |no   |yes  |prod|

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -21,7 +21,9 @@
 {{- end -}}
 
 {{- define "ingress.cluster-issuer" -}}
-  {{- if (regexMatch "^([a-zA-Z0-9-]+\\.)+(ok|okdc)(\\.dk)$" $.Values.ingress.host) }}
+  {{- if (regexMatch "^([a-zA-Z0-9-]+\\.)+(ok\\.dk)$" $.Values.ingress.host) }}
+      cloudflare-dns01-issuer
+  {{- else if (regexMatch "^([a-zA-Z0-9-]+\\.)+(okdc\\.dk)$" $.Values.ingress.host) }}
       clouddns-dns01-issuer
   {{- else if  (regexMatch "^([a-zA-Z0-9-]+\\.)+(okcloud\\.dk)$" $.Values.ingress.host) }}
       nginx-http01

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -1,3 +1,34 @@
+{{- define "ingress.classname" -}}
+  {{- if (regexMatch "^([a-zA-Z0-9-]+\\.)+(ok\\.dk)$" $.Values.ingress.host) }}
+    {{- if $.Values.ingress.isPrivate }}
+    # Allowed. We need ingressClassName to be the private ingress on gen 2. Which is nginx-private
+      nginx-private
+    {{- else }}
+    # Allowed. We need ingressClassName to be the public ingress on gen 2. Which is nginx
+      nginx
+    {{- end }}
+  {{- else if  (regexMatch "^([a-zA-Z0-9-]+\\.)+(okdc\\.dk)$" $.Values.ingress.host) }}
+    {{- if $.Values.ingress.isPrivate }}
+    # Allowed. We need ingressClassName to be the private ingress on gen 2. Which is nginx-private
+    nginx-private
+    {{- else }}
+    # Allowed. We need ingressClassName to be the public  ingress on gen 2. Which is nginx
+      nginx
+    {{- end }}
+  {{- else if  (regexMatch "^([a-zA-Z0-9-]+\\.)+(okcloud\\.dk)$" $.Values.ingress.host) }}
+    {{- if $.Values.ingress.isPrivate }}
+    # Not Allowed.
+      {{- fail "string here"}}
+    {{- else }}
+    # Allowed. We need ingressClassName to be the public  ingress on Cloud. Which is nginx
+      nginx
+    {{- end }}
+  {{- else }}
+  {{- fail "Parent domain not recognized"}}
+  {{- end }}
+{{- end -}}
+
+
 {{- define "deployment.name" -}}
 {{ .Values.fullnameOverride | default .Release.Name | trunc 63 | trimSuffix "-"}}
 {{- end -}}

--- a/charts/simple-deployment/templates/ingress.yaml
+++ b/charts/simple-deployment/templates/ingress.yaml
@@ -2,8 +2,8 @@
 {{- fail "The service is not enabled, which is a dependency for the ingress."}}
 {{- end }}
 
-{{- if regexMatch "^[a-zA-Z0-9.-]+\\.private\\.(?:test.|prodtest.|)okcloud\\.dk$" $.Values.ingress.host }}
-{{- fail "Private subdomain for okcloud.dk is not allowed"}}
+{{- if regexMatch "^[a-zA-Z0-9-]+\\.private\\.(?:test.|prodtest.|)okcloud\\.dk$" $.Values.ingress.host }}
+{{- fail "Private subdomain for okcloud.dk is not allowed."}}
 {{- end }}
 
 {{- if and (.Values.ingress.enable) (.Values.service.enable) }}
@@ -21,7 +21,7 @@ metadata:
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
-    {{- if regexMatch "^[a-zA-Z0-9.-]+\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host }}
+    {{- if or (regexMatch "^[a-zA-Z0-9-]+\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host) (regexMatch "^[a-zA-Z0-9-]+\\.private\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host) }}
     cert-manager.io/cluster-issuer: "clouddns-dns01-issuer"
     {{- else }}
     cert-manager.io/cluster-issuer: "nginx-http01"
@@ -38,7 +38,7 @@ metadata:
   {{- end }}
 spec:
   {{- if or (not $.Values.ingress.ingressClassName) (eq $.Values.ingress.ingressClassName "nginx") (eq $.Values.ingress.ingressClassName "nginx-public") }}
-  {{- if and (regexMatch "^[a-zA-Z0-9.-]+\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host)  (not (regexMatch "^[a-zA-Z0-9.-]+\\.private\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host)) }}
+  {{- if and (regexMatch "^[a-zA-Z0-9-]+\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host)  (not (regexMatch "^[a-zA-Z0-9-]+\\.private\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host)) }}
   ingressClassName: "nginx-public"
   {{- else }}
   ingressClassName: "nginx"

--- a/charts/simple-deployment/templates/ingress.yaml
+++ b/charts/simple-deployment/templates/ingress.yaml
@@ -2,6 +2,10 @@
 {{- fail "The service is not enabled, which is a dependency for the ingress."}}
 {{- end }}
 
+{{- if regexMatch "^[a-zA-Z0-9.-]+\\.private\\.(?:test.|prodtest.|)okcloud\\.dk$" $.Values.ingress.host }}
+{{- fail "Private subdomain for okcloud.dk is not allowed"}}
+{{- end }}
+
 {{- if and (.Values.ingress.enable) (.Values.service.enable) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -12,12 +16,16 @@ metadata:
     {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if or (not $.Values.ingress.ingressClassName) (eq $.Values.ingress.ingressClassName "nginx") }}
+    {{- if or (not $.Values.ingress.ingressClassName) (eq $.Values.ingress.ingressClassName "nginx") (eq $.Values.ingress.ingressClassName "nginx-public") }}
     {{- if .wwwRedirect }}
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
-    cert-manager.io/cluster-issuer: nginx-http01
+    {{- if regexMatch "^[a-zA-Z0-9.-]+\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host }}
+    cert-manager.io/cluster-issuer: "clouddns-dns01-issuer"
+    {{- else }}
+    cert-manager.io/cluster-issuer: "nginx-http01"
+    {{- end }}
     {{- end }}
   labels:
     {{- include "deployment.labels" $ | nindent 4 }}
@@ -29,9 +37,17 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.ingressClassName | default "nginx" }}
+  {{- if or (not $.Values.ingress.ingressClassName) (eq $.Values.ingress.ingressClassName "nginx") (eq $.Values.ingress.ingressClassName "nginx-public") }}
+  {{- if and (regexMatch "^[a-zA-Z0-9.-]+\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host)  (not (regexMatch "^[a-zA-Z0-9.-]+\\.private\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host)) }}
+  ingressClassName: "nginx-public"
+  {{- else }}
+  ingressClassName: "nginx"
+  {{- end }}
+  {{- else }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
-  - host: {{ .Values.ingress.host }}
+  - host: {{ $.Values.ingress.host }}
     http:
       paths:
       - path: /
@@ -42,13 +58,13 @@ spec:
             port:
               number: {{ .Values.deployment.container.containerPort | required "A container port is required on the container." }}
         {{- with .Values.ingress.addtionalPaths }}
-        {{ toYaml . | nindent 6}}
+        {{ toYaml . | nindent 6 }}
         {{- end }}
   tls:
   - hosts:
-    - {{ .Values.ingress.host }}
+    - {{ $.Values.ingress.host }}
     {{- if .Values.ingress.wwwRedirect }}
-    - "www.{{ .Values.ingress.host }}"
+    - "www.{{ $.Values.ingress.host }}"
     {{- end }}
-    secretName: "le-cert-{{ .Values.ingress.host | replace "." "-" | trunc 54 | trimSuffix "-" }}"
+    secretName: "le-cert-{{ $.Values.ingress.host | replace "." "-" | trunc 54 | trimSuffix "-" }}"
 {{- end }}

--- a/charts/simple-deployment/templates/ingress.yaml
+++ b/charts/simple-deployment/templates/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
-    cert-manager.io/cluster-issuer: nginx-http01
+    cert-manager.io/cluster-issuer: {{ include "ingress.cluster-issuer" $ | trim }}
     {{- end }}
   labels:
     {{- include "deployment.labels" $ | nindent 4 }}
@@ -29,7 +29,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.ingressClassName | default (include "ingress.classname" .) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | default ( include "ingress.classname" $) | trim }}
   rules:
   - host: {{ .Values.ingress.host }}
     http:
@@ -42,7 +42,7 @@ spec:
             port:
               number: {{ .Values.deployment.container.containerPort | required "A container port is required on the container." }}
         {{- with .Values.ingress.addtionalPaths }}
-        {{ toYaml . | nindent 6}}
+        {{ toYaml . | nindent 5}}
         {{- end }}
   tls:
   - hosts:

--- a/charts/simple-deployment/templates/ingress.yaml
+++ b/charts/simple-deployment/templates/ingress.yaml
@@ -2,10 +2,6 @@
 {{- fail "The service is not enabled, which is a dependency for the ingress."}}
 {{- end }}
 
-{{- if regexMatch "^[a-zA-Z0-9-]+\\.private\\.(?:test.|prodtest.|)okcloud\\.dk$" $.Values.ingress.host }}
-{{- fail "Private subdomain for okcloud.dk is not allowed."}}
-{{- end }}
-
 {{- if and (.Values.ingress.enable) (.Values.service.enable) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -16,16 +12,12 @@ metadata:
     {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if or (not $.Values.ingress.ingressClassName) (eq $.Values.ingress.ingressClassName "nginx") (eq $.Values.ingress.ingressClassName "nginx-public") }}
+    {{- if or (not $.Values.ingress.ingressClassName) (eq $.Values.ingress.ingressClassName "nginx") }}
     {{- if .wwwRedirect }}
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
-    {{- if or (regexMatch "^[a-zA-Z0-9-]+\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host) (regexMatch "^[a-zA-Z0-9-]+\\.private\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host) }}
-    cert-manager.io/cluster-issuer: "clouddns-dns01-issuer"
-    {{- else }}
-    cert-manager.io/cluster-issuer: "nginx-http01"
-    {{- end }}
+    cert-manager.io/cluster-issuer: nginx-http01
     {{- end }}
   labels:
     {{- include "deployment.labels" $ | nindent 4 }}
@@ -37,17 +29,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if or (not $.Values.ingress.ingressClassName) (eq $.Values.ingress.ingressClassName "nginx") (eq $.Values.ingress.ingressClassName "nginx-public") }}
-  {{- if and (regexMatch "^[a-zA-Z0-9-]+\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host)  (not (regexMatch "^[a-zA-Z0-9-]+\\.private\\.(?:test.|prodtest.|)okdc\\.dk$" $.Values.ingress.host)) }}
-  ingressClassName: "nginx-public"
-  {{- else }}
-  ingressClassName: "nginx"
-  {{- end }}
-  {{- else }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
-  {{- end }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | default (include "ingress.classname" .) }}
   rules:
-  - host: {{ $.Values.ingress.host }}
+  - host: {{ .Values.ingress.host }}
     http:
       paths:
       - path: /
@@ -58,13 +42,13 @@ spec:
             port:
               number: {{ .Values.deployment.container.containerPort | required "A container port is required on the container." }}
         {{- with .Values.ingress.addtionalPaths }}
-        {{ toYaml . | nindent 6 }}
+        {{ toYaml . | nindent 6}}
         {{- end }}
   tls:
   - hosts:
-    - {{ $.Values.ingress.host }}
+    - {{ .Values.ingress.host }}
     {{- if .Values.ingress.wwwRedirect }}
-    - "www.{{ $.Values.ingress.host }}"
+    - "www.{{ .Values.ingress.host }}"
     {{- end }}
-    secretName: "le-cert-{{ $.Values.ingress.host | replace "." "-" | trunc 54 | trimSuffix "-" }}"
+    secretName: "le-cert-{{ .Values.ingress.host | replace "." "-" | trunc 54 | trimSuffix "-" }}"
 {{- end }}

--- a/charts/simple-deployment/tests/ingress_test.yaml
+++ b/charts/simple-deployment/tests/ingress_test.yaml
@@ -16,7 +16,7 @@ tests:
         host: "example.private.test.okcloud.dk"
     asserts:
       - failedTemplate: 
-         ErrorMessage: "Private subdomain for okcloud.dk is not allowed"
+         ErrorMessage: "Private subdomain for okcloud.dk is not allowed."
 
   - it: "Should allow private as a subdomain of all environments in okdc.dk and also set the correct cluster-issuer and ingressClass"
     set: 
@@ -24,7 +24,7 @@ tests:
       deployment.container.containerPort: 8080
       ingress.enable: true
       ingress:
-        host: "example.private.test.okdc.dk"
+        host: "example.private.okdc.dk"
     asserts:
       - equal:
           path: "spec.ingressClassName"
@@ -34,7 +34,7 @@ tests:
           value: "clouddns-dns01-issuer"
       - matchRegex:
           path: "spec.rules[0].host"
-          pattern: "^[a-zA-Z0-9.-]+\\.private\\.(?:test.|prodtest.|)okdc\\.dk$"
+          pattern: "^[a-zA-Z0-9-]+\\.private\\.(?:test.|prodtest.|)okdc\\.dk$"
       - notFailedTemplate: {}
    
   - it: "Should allow public as a subdomain of all environments in okdc.dk and also set the correct cluster-issuer and ingressClass"
@@ -53,7 +53,7 @@ tests:
           value: "clouddns-dns01-issuer"
       - matchRegex:
           path: "spec.rules[0].host"
-          pattern: "^[a-zA-Z0-9.-]+\\.(?:test.|prodtest.|)okdc\\.dk$"
+          pattern: "^[a-zA-Z0-9-]+\\.(?:test.|prodtest.|)okdc\\.dk$"
       - notFailedTemplate: {}
 
   - it: "Should allow all public hosts in all environments in okcloud.dk and also set the correct cluster-issuer and ingressClass"

--- a/charts/simple-deployment/tests/ingress_test.yaml
+++ b/charts/simple-deployment/tests/ingress_test.yaml
@@ -1,0 +1,76 @@
+suite: Ingress host tests
+templates: 
+- "ingress.yaml"
+tests:
+# NOTE: The reason we do not have asserts in the first test, like the rest is because we need to put the host test into the template itself.
+#       This is done because the "failedTemplate" assertion matches, only if the ingress template fails. 
+#       When the failedTemplate" assertion matches, it is expecting that the error message in the ingress template is the same. 
+#       This way we are sure that the template is failing, explicitly because the user was trying to input an invalid hostname.
+
+  - it: "Should not allow private as a subdomain of okcloud.dk"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        host: "example.private.test.okcloud.dk"
+    asserts:
+      - failedTemplate: 
+         ErrorMessage: "Private subdomain for okcloud.dk is not allowed"
+
+  - it: "Should allow private as a subdomain of all environments in okdc.dk and also set the correct cluster-issuer and ingressClass"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        host: "example.private.test.okdc.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx"  # Expected value based on ingressClassName
+      - equal: 
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "clouddns-dns01-issuer"
+      - matchRegex:
+          path: "spec.rules[0].host"
+          pattern: "^[a-zA-Z0-9.-]+\\.private\\.(?:test.|prodtest.|)okdc\\.dk$"
+      - notFailedTemplate: {}
+   
+  - it: "Should allow public as a subdomain of all environments in okdc.dk and also set the correct cluster-issuer and ingressClass"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        host: "example.test.okdc.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-public"  # Expected value based on ingressClassName
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "clouddns-dns01-issuer"
+      - matchRegex:
+          path: "spec.rules[0].host"
+          pattern: "^[a-zA-Z0-9.-]+\\.(?:test.|prodtest.|)okdc\\.dk$"
+      - notFailedTemplate: {}
+
+  - it: "Should allow all public hosts in all environments in okcloud.dk and also set the correct cluster-issuer and ingressClass"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        host: "example.test.okcloud.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx"  # Expected value based on ingressClassName
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "nginx-http01"
+      - matchRegex:
+          path: "spec.rules[0].host"
+          pattern: "^[a-zA-Z0-9.-]+\\.(?:test.|prodtest.|)okcloud\\.dk$"
+      - notFailedTemplate: {}

--- a/charts/simple-deployment/tests/ingress_test.yaml
+++ b/charts/simple-deployment/tests/ingress_test.yaml
@@ -7,28 +7,18 @@ tests:
 #       When the failedTemplate" assertion matches, it is expecting that the error message in the ingress template is the same. 
 #       This way we are sure that the template is failing, explicitly because the user was trying to input an invalid hostname.
 
-  - it: "Should not allow private as a subdomain of okcloud.dk"
-    set: 
-      service.enable: true 
-      deployment.container.containerPort: 8080
-      ingress.enable: true
-      ingress:
-        host: "example.private.test.okcloud.dk"
-    asserts:
-      - failedTemplate: 
-         ErrorMessage: "Private subdomain for okcloud.dk is not allowed."
-
   - it: "Should allow private as a subdomain of all environments in okdc.dk and also set the correct cluster-issuer and ingressClass"
     set: 
       service.enable: true 
       deployment.container.containerPort: 8080
       ingress.enable: true
       ingress:
+        isPrivate: true
         host: "example.private.okdc.dk"
     asserts:
       - equal:
           path: "spec.ingressClassName"
-          value: "nginx"  # Expected value based on ingressClassName
+          value: "nginx-private"  # Expected value based on ingressClassName
       - equal: 
           path: "metadata.annotations['cert-manager.io/cluster-issuer']"
           value: "clouddns-dns01-issuer"
@@ -47,7 +37,7 @@ tests:
     asserts:
       - equal:
           path: "spec.ingressClassName"
-          value: "nginx-public"  # Expected value based on ingressClassName
+          value: "nginx"  # Expected value based on ingressClassName
       - equal:
           path: "metadata.annotations['cert-manager.io/cluster-issuer']"
           value: "clouddns-dns01-issuer"

--- a/charts/simple-deployment/tests/ingress_test.yaml
+++ b/charts/simple-deployment/tests/ingress_test.yaml
@@ -2,12 +2,8 @@ suite: Ingress host tests
 templates: 
 - "ingress.yaml"
 tests:
-# NOTE: The reason we do not have asserts in the first test, like the rest is because we need to put the host test into the template itself.
-#       This is done because the "failedTemplate" assertion matches, only if the ingress template fails. 
-#       When the failedTemplate" assertion matches, it is expecting that the error message in the ingress template is the same. 
-#       This way we are sure that the template is failing, explicitly because the user was trying to input an invalid hostname.
 
-  - it: "Should allow private as a subdomain of all environments in okdc.dk and also set the correct cluster-issuer and ingressClass"
+  - it: "1: Explicit private host with nginx-private and clouddns-dns01-issuer expected"
     set: 
       service.enable: true 
       deployment.container.containerPort: 8080
@@ -18,16 +14,28 @@ tests:
     asserts:
       - equal:
           path: "spec.ingressClassName"
-          value: "nginx-private"  # Expected value based on ingressClassName
-      - equal: 
+          value: "nginx-private"
+      - equal:
           path: "metadata.annotations['cert-manager.io/cluster-issuer']"
           value: "clouddns-dns01-issuer"
-      - matchRegex:
-          path: "spec.rules[0].host"
-          pattern: "^[a-zA-Z0-9-]+\\.private\\.(?:test.|prodtest.|)okdc\\.dk$"
-      - notFailedTemplate: {}
-   
-  - it: "Should allow public as a subdomain of all environments in okdc.dk and also set the correct cluster-issuer and ingressClass"
+
+  - it: "2: Explicit public host with nginx-public and clouddns-dns01-issuer expected"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: false
+        host: "example.test.okdc.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-public"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "clouddns-dns01-issuer"
+
+  - it: "3: Default which is implicit private host with nginx-private and clouddns-dns01-issuer expected"
     set: 
       service.enable: true 
       deployment.container.containerPort: 8080
@@ -37,16 +45,87 @@ tests:
     asserts:
       - equal:
           path: "spec.ingressClassName"
-          value: "nginx"  # Expected value based on ingressClassName
+          value: "nginx-private"
       - equal:
           path: "metadata.annotations['cert-manager.io/cluster-issuer']"
           value: "clouddns-dns01-issuer"
-      - matchRegex:
-          path: "spec.rules[0].host"
-          pattern: "^[a-zA-Z0-9-]+\\.(?:test.|prodtest.|)okdc\\.dk$"
-      - notFailedTemplate: {}
 
-  - it: "Should allow all public hosts in all environments in okcloud.dk and also set the correct cluster-issuer and ingressClass"
+  - it: "4: Explicit private host with nginx-private and clouddns-dns01-issuer expected"
+    set:  
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: true
+        host: "example.private.ok.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-private"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "clouddns-dns01-issuer"
+
+  - it: "5: Explicit public host with nginx-public and clouddns-dns01-issuer expected"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: false
+        host: "example.test.ok.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-public"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "clouddns-dns01-issuer"
+
+  - it: "6: Default which is implicit private host with nginx-private and clouddns-dns01-issuer expected"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        host: "example.test.ok.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-private"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "clouddns-dns01-issuer"
+
+  - it: "7: Should not allow okcloud services to be private"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: true
+        host: "example.private.okcloud.dk"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Services hosted in cloud are public only"
+
+  - it: "8: Explicit public in cloud with nginx and nginx-http01 expected"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: false
+        host: "example.test.okcloud.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "nginx-http01"
+
+  - it: "9: Default implicit public in cloud with nginx-http01 expected"
     set: 
       service.enable: true 
       deployment.container.containerPort: 8080
@@ -56,11 +135,31 @@ tests:
     asserts:
       - equal:
           path: "spec.ingressClassName"
-          value: "nginx"  # Expected value based on ingressClassName
+          value: "nginx"
       - equal:
           path: "metadata.annotations['cert-manager.io/cluster-issuer']"
           value: "nginx-http01"
-      - matchRegex:
-          path: "spec.rules[0].host"
-          pattern: "^[a-zA-Z0-9.-]+\\.(?:test.|prodtest.|)okcloud\\.dk$"
-      - notFailedTemplate: {}
+
+  - it: "10: Explicit Private in cloud with failed template expected"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: true
+        host: "example.private.okcloud.dk"
+    asserts:
+      - failedTemplate:
+        errorMessage: "Services hosted in cloud are public only"
+
+  - it: "11: Should not allow a domain in host we do not know"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: true
+        host: "example.blahblah.com"
+    asserts:
+      - failedTemplate:
+        errorMessage: "Parent domain not recognized"

--- a/charts/simple-deployment/tests/ingress_test.yaml
+++ b/charts/simple-deployment/tests/ingress_test.yaml
@@ -50,7 +50,7 @@ tests:
           path: "metadata.annotations['cert-manager.io/cluster-issuer']"
           value: "clouddns-dns01-issuer"
 
-  - it: "4: Explicit private host with nginx-private and clouddns-dns01-issuer expected"
+  - it: "4: Explicit private host with nginx-private and cloudflare-dns01-issuer expected"
     set:  
       service.enable: true 
       deployment.container.containerPort: 8080
@@ -64,9 +64,9 @@ tests:
           value: "nginx-private"
       - equal:
           path: "metadata.annotations['cert-manager.io/cluster-issuer']"
-          value: "clouddns-dns01-issuer"
+          value: "cloudflare-dns01-issuer"
 
-  - it: "5: Explicit public host with nginx-public and clouddns-dns01-issuer expected"
+  - it: "5: Explicit public host with nginx-public and cloudflare-dns01-issuer expected"
     set: 
       service.enable: true 
       deployment.container.containerPort: 8080
@@ -80,9 +80,9 @@ tests:
           value: "nginx-public"
       - equal:
           path: "metadata.annotations['cert-manager.io/cluster-issuer']"
-          value: "clouddns-dns01-issuer"
+          value: "cloudflare-dns01-issuer"
 
-  - it: "6: Default which is implicit private host with nginx-private and clouddns-dns01-issuer expected"
+  - it: "6: Default which is implicit private host with nginx-private and cloudflare-dns01-issuer expected"
     set: 
       service.enable: true 
       deployment.container.containerPort: 8080
@@ -95,7 +95,7 @@ tests:
           value: "nginx-private"
       - equal:
           path: "metadata.annotations['cert-manager.io/cluster-issuer']"
-          value: "clouddns-dns01-issuer"
+          value: "cloudflare-dns01-issuer"
 
   - it: "7: Should not allow okcloud services to be private"
     set: 


### PR DESCRIPTION
# This PR adds support for the following

## Private ingress on Gen 2 kubernetes platform using the boolean isPrivate.
- New defaults for ingressClassName.
  - without breaking backwards compatibility in GCP cloud.
  - without breaking support for overwriting ingressClassName in the services' values file.
  - with private by default on Gen 2 kubernetes platform and support for public to comply with CISO.
  - with public by default in GKE cloud platform, and private not supported.
  
- The boolean is not set by default in global values, to support different default in GCP and on premises.
- The cluster-issuer is adapting to the cluster your service is deployed in. 
- This PR includes unittests for the differents cases that we now support in Simple-deployment. 
- The different scenarios in this release have been tested in dev release 
     - --version 2.3.0-a15d463902c294ad9c3c5e9793e994b5968dc72b

- The readme has been updated to explain support for private ingress. Also showing how to make your service public on Gen 2.