### PR TITLE
feat: Added support for private ingress - Helm unittests included

### DIFF
--- a/charts/legend-deployment/Chart.yaml
+++ b/charts/legend-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: legend-deployment
 description: A Helm chart for a legend deployment, incl. service and ingress, while also have support for gatekeeper and environment variable secrets
-version: 1.2.0
+version: 1.3.0

--- a/charts/legend-deployment/README.md
+++ b/charts/legend-deployment/README.md
@@ -123,3 +123,39 @@ ingress:
         port:
           number: 3000
 ```
+## Example 5
+
+**The new ingress in Gen 2 supports private or public mode**
+
+### Example 5.1: Configuring a private ingress
+If you want to deploy a new service on the ok.dk or okdc.dk domain, and want to expose the ingress privately in OK, the following example can be used. In this case 'isPrivate' is set to true.
+
+```yaml
+ingress:
+  enable: true
+  host: example.private.test.okdc.dk
+  isPrivate: true
+```
+
+### Example 5.2: Configuring a public ingress
+If you want to deploy a service on the ok.dk or okdc.dk domain, and want to expose the ingress publicly, the following example can be used. In this case 'isPrivate' is set to false.
+
+```yaml
+ingress:
+  enable: true
+  host: example.test.ok.dk
+  isPrivate: false
+```
+
+### 5.3: Using the default privacy of a domain
+If you do NOT specify 'isPrivate' on an ingress controller the domains default will be used instead. Reference the following table for defaults.
+|Domain|Default privacy|
+|---|---|
+|*.ok.dk|private|
+
+The below example will result in a private ingress because the host is using the ok.dk domain.
+```yaml
+ingress:
+  enable: true
+  host: example.test.ok.dk
+```

--- a/charts/legend-deployment/templates/_helpers.tpl
+++ b/charts/legend-deployment/templates/_helpers.tpl
@@ -1,6 +1,31 @@
+{{- define "ingress.classname" -}}
+  {{- if (regexMatch "^([a-zA-Z0-9-]+\\.)+(ok|okdc)(\\.dk)$" $.Values.ingress.host) }}
+    {{- if (eq nil $.Values.ingress.isPrivate) }}
+     nginx-private
+    {{- else if ($.Values.ingress.isPrivate) }}
+      nginx-private
+    {{- else }}
+      nginx-public
+    {{- end }}
+  {{- else }}
+    {{- fail "Parent domain not recognized"}}
+  {{- end }}
+{{- end -}}
+
+{{- define "ingress.cluster-issuer" -}}
+  {{- if (regexMatch "^([a-zA-Z0-9-]+\\.)+(ok\\.dk)$" $.Values.ingress.host) }}
+      cloudflare-dns01-issuer
+  {{- else if (regexMatch "^([a-zA-Z0-9-]+\\.)+(okdc\\.dk)$" $.Values.ingress.host) }}
+      clouddns-dns01-issuer
+  {{- else }}
+   {{- fail "Parent domain not recognized"}}
+  {{- end }}
+{{- end -}}
+
 {{- define "deployment.name" -}}
 {{ .Values.fullnameOverride | default .Release.Name | trunc 63 | trimSuffix "-"}}
 {{- end -}}
+
 
 {{- define "deployment.labels" -}}
 app: {{ include "deployment.name" $ | quote }}

--- a/charts/legend-deployment/templates/ingress.yaml
+++ b/charts/legend-deployment/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     {{- end }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ .sslRedirect | default "false" | quote }}
-    cert-manager.io/cluster-issuer: nginx-http01
+    cert-manager.io/cluster-issuer: {{ include "ingress.cluster-issuer" $ | trim }}
   labels:
     {{- include "deployment.labels" $ | nindent 4 }}
     {{- range $k, $v := .labels }}
@@ -27,7 +27,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.ingressClassName | default "nginx" }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | default ( include "ingress.classname" $) | trim }}
   rules:
   - host: {{ .Values.ingress.host }}
     http:

--- a/charts/legend-deployment/tests/ingress_test.yaml
+++ b/charts/legend-deployment/tests/ingress_test.yaml
@@ -1,0 +1,110 @@
+suite: Ingress host tests
+templates: 
+- "ingress.yaml"
+tests:
+
+  - it: "1: Explicit private host with nginx-private and clouddns-dns01-issuer expected"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: true
+        host: "example.private.okdc.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-private"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "clouddns-dns01-issuer"
+
+  - it: "2: Explicit public host with nginx-public and clouddns-dns01-issuer expected"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: false
+        host: "example.test.okdc.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-public"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "clouddns-dns01-issuer"
+
+  - it: "3: Default which is implicit private host with nginx-private and clouddns-dns01-issuer expected"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        host: "example.test.okdc.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-private"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "clouddns-dns01-issuer"
+
+  - it: "4: Explicit private host with nginx-private and cloudflare-dns01-issuer expected"
+    set:  
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: true
+        host: "example.private.ok.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-private"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "cloudflare-dns01-issuer"
+
+  - it: "5: Explicit public host with nginx-public and cloudflare-dns01-issuer expected"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: false
+        host: "example.test.ok.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-public"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "cloudflare-dns01-issuer"
+
+  - it: "6: Default which is implicit private host with nginx-private and cloudflare-dns01-issuer expected"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        host: "example.test.ok.dk"
+    asserts:
+      - equal:
+          path: "spec.ingressClassName"
+          value: "nginx-private"
+      - equal:
+          path: "metadata.annotations['cert-manager.io/cluster-issuer']"
+          value: "cloudflare-dns01-issuer"
+
+  - it: "7: Should not allow a domain in host we do not know"
+    set: 
+      service.enable: true 
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        isPrivate: true
+        host: "example.blahblah.com"
+    asserts:
+      - failedTemplate:
+        errorMessage: "Parent domain not recognized"


### PR DESCRIPTION
##  Private ingress on Gen 2 kubernetes platform using the boolean isPrivate.
- New defaults for ingressClassName.
  - Without breaking support for overwriting ingressClassName in the services' values file.
  - With private by default on Gen 2 kubernetes platform and support for public to comply with CISO.
  - The boolean is not set by default in global values, to support different default in GCP and on premises.
  - Support for ok.dk and okdc.dk public and private domain names.

- The cluster-issuer is adapting to the cluster your service is deployed in.

- This PR includes unittests for the different cases that we now support in Legend-deployment.

- The different scenarios in this release have been tested in templates.
- The readme has been updated to explain support for private ingress. Also showing how to make your service public on Gen 2.

### Legend-deployment has been bumped to v. 1.3.0.