### PR TITLE
Bug: fix missing volumes for external screts

### DIFF
--- a/charts/legend-deployment/Chart.yaml
+++ b/charts/legend-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: legend-deployment
 description: A Helm chart for a legend deployment, incl. service and ingress, while also have support for gatekeeper and environment variable secrets
-version: 2.0.0
+version: 3.0.1

--- a/charts/legend-deployment/README.md
+++ b/charts/legend-deployment/README.md
@@ -152,7 +152,7 @@ In order to use the external secret store to create a kubernetes secret, the leg
 ```
 It's possible to map one to one or multiple remote secrets into one kubernetes secret. The secret will automatically be mounted as a file with path `/secrets/<SECRET NAME>/<KEY NAME>`.
 
-Another possiblity is to reference the secret as an environment variable directly. However this is not recommended due to how trivial it is inspect a Containers environment variables. This approach is only recommended during migration of a service.
+Another possiblity is to reference the secret as an environment variable directly. However this is not recommended due to how trivial it is inspect a container environment variables. This approach is only recommended during migration of a service.
 
 ``` yaml
   deployment:
@@ -163,9 +163,5 @@ Another possiblity is to reference the secret as an environment variable directl
         - secretKey: "key1"
           refName: "remote-secret-ref1"
 
-      secretRefEnvironment:
-      - name: "environment-variable-name1"
-        secret: "kubernetes-secret-name1"
-        key: "key1"
 ```
-In this case the secret in the remote store should be named `SecretName__refName` e. g. `kubernetes-secret-name1__key1`. e. g.the output will then be kubernetes secret with name `kubernetes-secret-name1` with key `key1`. This is a limitation of the remote store not being able to contain multiple keys and naming conventions for a given kubernetes secret. The secret can then be referenced using `secretRefEnvironment` to inject the secret as an environment variable.
+In this case the secret in the remote store should be named `SecretName__secretKey` e. g. `kubernetes-secret-name1__key1`. e. g.the output will then be kubernetes secret with name `kubernetes-secret-name1` with key `key1`. This is a limitation of the remote store not being able to contain multiple keys and naming conventions for a given kubernetes secret. The secret is automatically referenced as an environment variable with the refName so that an environment variable is created with name e. g. `remote-secret-ref1`.

--- a/charts/legend-deployment/README.md
+++ b/charts/legend-deployment/README.md
@@ -164,4 +164,13 @@ Another possiblity is to reference the secret as an environment variable directl
           refName: "remote-secret-ref1"
 
 ```
-In this case the secret in the remote store should be named `SecretName__secretKey` e. g. `kubernetes-secret-name1__key1`. e. g.the output will then be kubernetes secret with name `kubernetes-secret-name1` with key `key1`. This is a limitation of the remote store not being able to contain multiple keys and naming conventions for a given kubernetes secret. The secret is automatically referenced as an environment variable with the refName so that an environment variable is created with name e. g. `remote-secret-ref1`.
+In this case the secret in the remote store should be named `SecretName__secretKey` e. g. `kubernetes-secret-name1__key1`. e. g.the output will then be kubernetes secret with name `kubernetes-secret-name1` with key `key1`. This is a limitation of the remote store not being able to contain multiple keys and naming conventions for a given kubernetes secret. The secret is automatically referenced as an environment variable with the refName so that an environment variable is created with name e. g. `remote-secret-ref1`. The secret can be mapped to another environment variable with:
+
+``` yaml
+  deployment:
+    container:
+      secretEnvironmentRef:
+      - name: "environment-variable1"
+        secret: "kubernetes-secret-name1"
+        key: "key1"
+```

--- a/charts/legend-deployment/templates/deployment.yaml
+++ b/charts/legend-deployment/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         readinessProbe:
         {{- include "deployment.readinessProbe" . | nindent 10 }}
         {{- end }}
-        {{- if or .environment .fieldRefEnvironment .externalSecretsRef }}
+        {{- if or .environment .fieldRefEnvironment .secretEnvironmentRef .externalSecretsRef}}
         env:
           {{- range $name, $value := .fieldRefEnvironment }}
           - name: {{ $name }}
@@ -87,6 +87,13 @@ spec:
           {{- range $name, $value := .environment }}
           - name: {{ $name }}
             value: {{ $value | quote }}
+          {{- end }}
+          {{- range $value := .secretEnvironmentRef }}
+          - name: {{ $value.name }}
+            valueFrom:
+              secretKeyRef:
+                key: {{ $value.key }}
+                name: {{ $value.secret }}
           {{- end }}
           {{- range $externalSecretRef := .externalSecretsRef }}
           {{- range $remoteSecret := $externalSecretRef.data }}

--- a/charts/legend-deployment/templates/deployment.yaml
+++ b/charts/legend-deployment/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         readinessProbe:
         {{- include "deployment.readinessProbe" . | nindent 10 }}
         {{- end }}
-        {{- if or .environment .fieldRefEnvironment .secretRefEnvironment }}
+        {{- if or .environment .fieldRefEnvironment .externalSecretsRef }}
         env:
           {{- range $name, $value := .fieldRefEnvironment }}
           - name: {{ $name }}
@@ -88,12 +88,14 @@ spec:
           - name: {{ $name }}
             value: {{ $value | quote }}
           {{- end }}
-          {{- range $value := .secretRefEnvironment }}
-          - name: {{ $value.name }}
+          {{- range $externalSecretRef := .externalSecretsRef }}
+          {{- range $remoteSecret := $externalSecretRef.data }}
+          - name: {{ $remoteSecret.refName }}
             valueFrom:
               secretKeyRef:
-                key: {{ $value.key }}
-                name: {{ $value.secret }}
+                key: {{ $remoteSecret.secretKey }}
+                name: {{ $externalSecretRef.secretName }}
+          {{- end }}
           {{- end }}
         {{- end }}
 
@@ -105,11 +107,16 @@ spec:
           {{- end }}
         {{- end }}
 
-        {{- if or .secrets .configMaps .additionalVolumeMounts }}
+        {{- if or .secrets .configMaps .additionalVolumeMounts .externalSecrets  }}
         volumeMounts:
           {{- range $secret := .secrets }}
           - name: {{ $secret }}
             mountPath: /secrets/{{ $secret }}
+            readOnly: true
+          {{- end }}
+          {{- range $externalSecret := .externalSecrets }}
+          - name: {{ $externalSecret.name }}
+            mountPath: /secrets/{{ $externalSecret.name }}
             readOnly: true
           {{- end }}
           {{- range $configMap := .configMaps }}
@@ -128,7 +135,7 @@ spec:
       {{- include "deployment.cloudSQLProxy" $ | nindent 6 }}
       {{- include "deployment.gatekeeper" $ | nindent 6 }}
       {{- with .Values.deployment }}
-      {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.configMaps .additionalVolumes }}
+      {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.externalSecrets .container.configMaps .additionalVolumes }}
       volumes:
         {{- if and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName }}
         - name: {{ .cloudSQLProxy.secretKeyName }}
@@ -142,6 +149,11 @@ spec:
           secret:
             secretName: {{ $secret }}
         {{- end }}
+        {{- end }}
+        {{- range $externalSecret := .externalSecrets }}
+        - name: {{ $externalSecret.name }}
+          secret:
+            secretName: {{ $externalSecret.name }}
         {{- end }}
         {{- range $configMap := .configMaps }}
         - name: {{ $configMap.name }}

--- a/charts/legend-deployment/templates/deployment.yaml
+++ b/charts/legend-deployment/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         readinessProbe:
         {{- include "deployment.readinessProbe" . | nindent 10 }}
         {{- end }}
-        {{- if or .environment .fieldRefEnvironment .secretEnvironmentRef .externalSecretsRef}}
+        {{- if or .environment .fieldRefEnvironment .secretRef .externalSecretsRef}}
         env:
           {{- range $name, $value := .fieldRefEnvironment }}
           - name: {{ $name }}
@@ -88,7 +88,7 @@ spec:
           - name: {{ $name }}
             value: {{ $value | quote }}
           {{- end }}
-          {{- range $value := .secretEnvironmentRef }}
+          {{- range $value := .secretRef }}
           - name: {{ $value.name }}
             valueFrom:
               secretKeyRef:

--- a/charts/legend-deployment/tests/external-secret-ref_test.yaml
+++ b/charts/legend-deployment/tests/external-secret-ref_test.yaml
@@ -46,7 +46,7 @@ tests:
               - secretKey: "secret4-key"
                 refName: "secret4-ref-name"
 
-          secretEnvironmentRef:
+          secretRef:
           - name: "environment-variable2"
             secret: "kubernetes-secret-name1"
             key: "key1"

--- a/charts/legend-deployment/tests/external-secret-ref_test.yaml
+++ b/charts/legend-deployment/tests/external-secret-ref_test.yaml
@@ -15,7 +15,8 @@ tests:
     asserts:
       - hasDocuments:
           count: 2
-  - it: "should create more than one secret"
+  
+  - it: "should create an external secret with a remote ref that is secretName__secretKey"
     template: external-secret-ref.yaml
     set:
       deployment.container.externalSecretsRef:
@@ -29,6 +30,10 @@ tests:
       - equal:
           path: spec.data[0].secretKey
           value: "secret3-key"
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: "secret3-name__secret3-ref-key"
+
   - it: "Should create env in deployment"
     template: deployment.yaml
     set:

--- a/charts/legend-deployment/tests/external-secret-ref_test.yaml
+++ b/charts/legend-deployment/tests/external-secret-ref_test.yaml
@@ -4,14 +4,14 @@ tests:
     template: external-secret-ref.yaml
     set:
       deployment.container.externalSecretsRef:
-        - secretName: "easyparkhubinterfaceapi"
+        - secretName: "secret1-name"
           data:
-            - secretKey: "aalborgauthorizationtoken"
-              refName: "AalborgApiAuthorizationToken"
-        - secretName: "easyparkhubinterfaceapi"
+            - secretKey: "secret1-key"
+              refName: "secret1-ref-name"
+        - secretName: "secret2-name"
           data:
-            - secretKey: "aalborgauthorizationtoken"
-              refName: "AalborgApiAuthorizationToken"
+            - secretKey: "secret2-key"
+              refName: "secret2-ref-name"
     asserts:
       - hasDocuments:
           count: 2
@@ -19,26 +19,26 @@ tests:
     template: external-secret-ref.yaml
     set:
       deployment.container.externalSecretsRef:
-        - secretName: "easyparkhubinterfaceapi"
+        - secretName: "secret3-name"
           data:
-            - secretKey: "aalborgauthorizationtoken"
-              refName: "AalborgApiAuthorizationToken"
+            - secretKey: "secret3-key"
+              refName: "secret3-ref-name"
     asserts:
       - hasDocuments:
           count: 1
       - equal:
           path: spec.data[0].secretKey
-          value: "aalborgauthorizationtoken"
+          value: "secret3-key"
   - it: "Should create env in deployment"
     template: deployment.yaml
     set:
       deployment.name: "test"
       deployment.container.externalSecretsRef:
-        - secretName: "easyparkhubinterfaceapi"
+        - secretName: "secret4-name"
           data:
-            - secretKey: "aalborgauthorizationtoken"
-              refName: "AalborgApiAuthorizationToken"
+            - secretKey: "secret4-key"
+              refName: "secret4-ref-name"
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].name
-          value: AalborgApiAuthorizationToken
+          value: "secret4-ref-name"

--- a/charts/legend-deployment/tests/external-secret-ref_test.yaml
+++ b/charts/legend-deployment/tests/external-secret-ref_test.yaml
@@ -32,18 +32,29 @@ tests:
           value: "secret3-key"
       - equal:
           path: spec.data[0].remoteRef.key
-          value: "secret3-name__secret3-ref-key"
+          value: "secret3-name__secret3-key"
 
-  - it: "Should create env in deployment"
+  - it: "Should create env in deployment and be able to reference secret"
     template: deployment.yaml
     set:
       deployment.name: "test"
-      deployment.container.externalSecretsRef:
-        - secretName: "secret4-name"
-          data:
-            - secretKey: "secret4-key"
-              refName: "secret4-ref-name"
+      deployment:
+        container:
+          externalSecretsRef:
+          - secretName: "secret4-name"
+            data:
+              - secretKey: "secret4-key"
+                refName: "secret4-ref-name"
+
+          secretEnvironmentRef:
+          - name: "environment-variable2"
+            secret: "kubernetes-secret-name1"
+            key: "key1"
+
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].name
+          value: "environment-variable2"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
           value: "secret4-ref-name"

--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 3.0.0
+version: 4.0.1

--- a/charts/simple-deployment/templates/deployment.yaml
+++ b/charts/simple-deployment/templates/deployment.yaml
@@ -96,11 +96,16 @@ spec:
           {{- end }}
         {{- end }}
 
-        {{- if or .secrets .configMaps .additionalVolumeMounts }}
+        {{- if or .secrets .configMaps .additionalVolumeMounts .externalSecrets }}
         volumeMounts:
           {{- range $secret := .secrets }}
           - name: {{ $secret }}
             mountPath: /secrets/{{ $secret }}
+            readOnly: true
+          {{- end }}
+          {{- range $externalSecret := .externalSecrets }}
+          - name: {{ $externalSecret.name }}
+            mountPath: /secrets/{{ $externalSecret.name }}
             readOnly: true
           {{- end }}
           {{- range $configMap := .configMaps }}
@@ -118,7 +123,7 @@ spec:
       {{- end }}
       {{- include "deployment.cloudSQLProxy" $ | nindent 6 }}
       {{- with .Values.deployment }}
-      {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.configMaps .additionalVolumes }}
+      {{- if or (and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName) .container.secrets .container.externalSecrets .container.configMaps .additionalVolumes }}
       volumes:
         {{- if and .cloudSQLProxy.enable .cloudSQLProxy.secretKeyName }}
         - name: {{ .cloudSQLProxy.secretKeyName }}
@@ -133,6 +138,11 @@ spec:
           secret:
             secretName: {{ $secret }}
         {{- end }}
+        {{- end }}
+        {{- range $externalSecret := .externalSecrets }}
+        - name: {{ $externalSecret.name }}
+          secret:
+            secretName: {{ $externalSecret.name }}
         {{- end }}
         {{- range $configMap := .configMaps }}
         - name: {{ $configMap.name }}


### PR DESCRIPTION
The implementation of external secret was not added correctly in the first PR. the unit tests was created but the actual implementation was lost. This PR introduces breaking changes related to the syntax but is bundled with the latest breaking changes
