### PR TITLE
Fix/simple deployment 5.0.1 unittests

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 5.0.0
+version: 5.0.1

--- a/charts/simple-deployment/tests/ingress_test.yaml
+++ b/charts/simple-deployment/tests/ingress_test.yaml
@@ -9,6 +9,7 @@ tests:
       deployment.container.containerPort: 8080
       ingress.enable: true
       ingress:
+        host: "example.test.ok.dk"
         exposure: internalOK
         cluster: "Gen 2"
     asserts:
@@ -25,6 +26,7 @@ tests:
       deployment.container.containerPort: 8080
       ingress.enable: true
       ingress:
+        host: "example.test.ok.dk"
         exposure: public
         cluster: "Gen 2"
     asserts:
@@ -41,6 +43,7 @@ tests:
       deployment.container.containerPort: 8080
       ingress.enable: true
       ingress:
+        host: "example.test.ok.dk"
         cluster: "Gen 2"
     asserts:
       - equal:
@@ -56,6 +59,7 @@ tests:
       deployment.container.containerPort: 8080
       ingress.enable: true
       ingress:
+        host: "example.test.ok.dk"
         exposure: public
         cluster: "cloud"
     asserts:
@@ -72,6 +76,7 @@ tests:
       deployment.container.containerPort: 8080
       ingress.enable: true
       ingress:
+        host: "example.test.ok.dk"
         cluster: "cloud"
     asserts:
       - equal:
@@ -99,18 +104,29 @@ tests:
       deployment.container.containerPort: 8080
       ingress.enable: true
       ingress:
-        host: "gen 1"
+        cluster: "Gen 1"
+    asserts:
+      - failedTemplate:
+        errorMessage: "Cluster not recognized."
+
+  - it: "8: Should not allow a domain name we do not know."
+    set:
+      service.enable: true
+      deployment.container.containerPort: 8080
+      ingress.enable: true
+      ingress:
+        host: "example.test.okblah.dk"
     asserts:
       - failedTemplate:
         errorMessage: "Parent domain not recognized."
 
-
-  - it: "8: Should work with custom ingress"
+  - it: "9: Should work with custom ingress"
     set:
       service.enable: true
       deployment.container.containerPort: 8080
       ingress:
         enable: true
+        host: "example.test.ok.dk"
         cluster: "cloud"
         ingressClassName: haproxy
     asserts:


### PR DESCRIPTION
Correct unittests for passing with the new cluster variable logic and functionality.
Especially test 7, 8 and 9.