### PR TITLE
113739: feature: include exposure and cluster as parameters in default values

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 5.0.1
+version: 5.0.2

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -186,7 +186,7 @@ ingress:
   exposure: null
 
   # Define what cluster you want to deploy your service in.
-  cluster: null
+  cluster: "null"
 
 
 ##################################################

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -181,6 +181,14 @@ ingress:
   #       port:
   #         number: 3000
 
+  # Define what exposure you want for your application.
+  # Default is set based on the cluster.
+  exposure: null
+
+  # Define what cluster you want to deploy your service in.
+  cluster: null
+
+
 ##################################################
 #           Pod Disruption Budget               #
 ##################################################


### PR DESCRIPTION
As per request from our developers. The exposure and cluster parameters should be included in the default values.yaml file for simple-deployment. That way they know what minimum parameters they have to include in order when creating a helm chart for their service.

https://dev.azure.com/okamba/Infrastruktur/_boards/board/t/Infrastruktur%20-%20Platform/Stories?text=simple-de&workitem=113739