### PR TITLE
chore: bump external-secret apiversion from beta to ga

### DIFF
--- a/charts/legend-deployment/Chart.yaml
+++ b/charts/legend-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: legend-deployment
 description: A Helm chart for a legend deployment, incl. service and ingress, while also have support for gatekeeper and environment variable secrets
-version: 3.1.1
+version: 3.1.2

--- a/charts/legend-deployment/templates/external-secret-ref.yaml
+++ b/charts/legend-deployment/templates/external-secret-ref.yaml
@@ -1,5 +1,5 @@
 {{- range $secret := .Values.deployment.container.externalSecretsRef}}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secret.secretName }}

--- a/charts/legend-deployment/templates/external-secret.yaml
+++ b/charts/legend-deployment/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 {{- range $secret := .Values.deployment.container.externalSecrets}}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secret.name }}

--- a/charts/nats-streaming/Chart.yaml
+++ b/charts/nats-streaming/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: nats-streaming
 description: Stan helm chart fork that supports configuring auth through secrets. Only used for migration purposes and no maintenance effort planned. 
-version: 0.1.0
+version: 0.1.1

--- a/charts/nats-streaming/templates/externalsecret.yaml
+++ b/charts/nats-streaming/templates/externalsecret.yaml
@@ -1,7 +1,7 @@
 {{- if and $.Values.stan.auth.enabled $.Values.stan.auth.secretRef.externalSecret.enabled }}
 ---
 {{- $secretName := ($.Values.stan.auth.secretRef.secret | default "google-secret-manager") }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $.Values.stan.auth.secretRef.secret }}

--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 5.0.2
+version: 5.0.3

--- a/charts/simple-deployment/templates/external-secret.yaml
+++ b/charts/simple-deployment/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 {{- range $secret := .Values.deployment.container.externalSecrets }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secret.name }}


### PR DESCRIPTION
This PR has spawned due to: 
https://dev.azure.com/okamba/Infrastruktur/_boards/board/t/Infrastruktur%20-%20Platform/Stories?System.AssignedTo=%40me%2C_Unassigned_&workitem=113396

We are on ESO version 0.16.2
The beta API is being deprecated from 0.17.x onwards. 

The ESO version we are on supports the GA API.

Should have 0 consequences at the time of implementation. 

When the ESO is bumped to 0.17.0+ the support for the beta api is gone, so we need to inform the developers that they need to bump to the version of the charts thats created when this change is deployed, in order for their ExternalSecrets to work just as before. 