### PR TITLE
simple-deployment: add startupProbe support and bump to 5.1.0

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 5.0.3
+version: 5.1.0

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -82,6 +82,17 @@ successThreshold: {{ .readinessProbe.failureThreshold | default 1 }}
 failureThreshold: {{ .readinessProbe.failureThreshold | default 3 }}
 {{- end -}}
 
+{{- define "deployment.startupProbe" -}}
+httpGet:
+  path: {{ .startupProbe.httpGet.path }}
+  port: {{ .containerPort }}
+initialDelaySeconds: {{ .startupProbe.initialDelaySeconds | default 0 }}
+periodSeconds: {{ .startupProbe.periodSeconds | default 10}}
+timeoutSeconds: {{ .startupProbe.timeoutSeconds | default 1 }}
+successThreshold: {{ .startupProbe.failureThreshold | default 1 }}
+failureThreshold: {{ .startupProbe.failureThreshold | default 60 }}
+{{- end -}}
+
 {{- define "deployment.cloudSQLProxy" -}}
 {{- with .Values.deployment -}}
 {{- if .cloudSQLProxy.enable }}

--- a/charts/simple-deployment/templates/deployment.yaml
+++ b/charts/simple-deployment/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
         readinessProbe:
         {{- include "deployment.readinessProbe" . | nindent 10 }}
         {{- end }}
+        {{- if .startupProbe.enable }}
+        startupProbe:
+        {{- include "deployment.startupProbe" . | nindent 10 }}
+        {{- end }}
         {{- if or .environment .fieldRefEnvironment }}
         env:
           {{- range $name, $value := .environment }}

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -69,6 +69,11 @@ deployment:
       httpGet:
         path: /readyz
 
+    startupProbe:
+      enable: false
+      httpGet:
+        path: /healthz
+
     environment: {}
       # SOME_ENV: some-value
 


### PR DESCRIPTION
This PR has is a product of:
https://dev.azure.com/okamba/Infrastruktur/_workitems/edit/110896

## Changes
- Added startupProbe support to the simple-deployment chart
- Bumped chart version from 5.0.3 to 5.1.0
- Added startupProbe configuration in values.yaml (disabled by default)
- Added startupProbe template in _helpers.tpl
- Updated deployment.yaml to conditionally include startupProbe

## Configuration
The startupProbe is disabled by default and can be enabled via:
```yaml
deployment:
  startupProbe:
    enable: true
    httpGet:
      path: /healthz
```

## Impact
- No breaking changes - startupProbe is opt-in
- Existing deployments will continue to work unchanged
- New deployments can optionally enable startupProbe for better container startup handling