### PR TITLE
Fix/probe threshold separation

### DIFF
--- a/charts/legend-deployment/Chart.yaml
+++ b/charts/legend-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: legend-deployment
 description: A Helm chart for a legend deployment, incl. service and ingress, while also have support for gatekeeper and environment variable secrets
-version: 3.1.2
+version: 3.1.3

--- a/charts/legend-deployment/templates/_helpers.tpl
+++ b/charts/legend-deployment/templates/_helpers.tpl
@@ -56,7 +56,7 @@ httpGet:
 initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds | default 5 }}
 periodSeconds: {{ .livenessProbe.periodSeconds | default 10}}
 timeoutSeconds: {{ .livenessProbe.timeoutSeconds | default 1 }}
-successThreshold: {{ .livenessProbe.failureThreshold | default 1 }}
+successThreshold: {{ .livenessProbe.successThreshold | default 1 }}
 failureThreshold: {{ .livenessProbe.failureThreshold | default 3 }}
 {{- end -}}
 
@@ -67,7 +67,7 @@ httpGet:
 initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds | default 5 }}
 periodSeconds: {{ .readinessProbe.periodSeconds | default 10}}
 timeoutSeconds: {{ .readinessProbe.timeoutSeconds | default 1 }}
-successThreshold: {{ .readinessProbe.failureThreshold | default 1 }}
+successThreshold: {{ .readinessProbe.successThreshold | default 1 }}
 failureThreshold: {{ .readinessProbe.failureThreshold | default 3 }}
 {{- end -}}
 

--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 5.2.1
+version: 5.2.2

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -67,7 +67,7 @@ httpGet:
 initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds | default 5 }}
 periodSeconds: {{ .livenessProbe.periodSeconds | default 10}}
 timeoutSeconds: {{ .livenessProbe.timeoutSeconds | default 1 }}
-successThreshold: {{ .livenessProbe.failureThreshold | default 1 }}
+successThreshold: {{ .livenessProbe.successThreshold | default 1 }}
 failureThreshold: {{ .livenessProbe.failureThreshold | default 3 }}
 {{- end -}}
 
@@ -78,7 +78,7 @@ httpGet:
 initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds | default 5 }}
 periodSeconds: {{ .readinessProbe.periodSeconds | default 10}}
 timeoutSeconds: {{ .readinessProbe.timeoutSeconds | default 1 }}
-successThreshold: {{ .readinessProbe.failureThreshold | default 1 }}
+successThreshold: {{ .readinessProbe.successThreshold | default 1 }}
 failureThreshold: {{ .readinessProbe.failureThreshold | default 3 }}
 {{- end -}}
 
@@ -89,7 +89,7 @@ httpGet:
 initialDelaySeconds: {{ .startupProbe.initialDelaySeconds | default 0 }}
 periodSeconds: {{ .startupProbe.periodSeconds | default 10}}
 timeoutSeconds: {{ .startupProbe.timeoutSeconds | default 1 }}
-successThreshold: {{ .startupProbe.failureThreshold | default 1 }}
+successThreshold: {{ .startupProbe.successThreshold | default 1 }}
 failureThreshold: {{ .startupProbe.failureThreshold | default 60 }}
 {{- end -}}
 


### PR DESCRIPTION
Fixed a bug in the Helm chart deployment templates where successThreshold was incorrectly referencing failureThreshold instead of having its own independent value. This affected liveness, readiness, and startup probes in both simple-deployment and legend-deployment charts.