### PR TITLE
US117933: Simple-deployment: Set default container port

### DIFF
--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 5.2.3
+version: 5.3.0

--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 5.2.2
+version: 5.2.3

--- a/charts/simple-deployment/Chart.yaml
+++ b/charts/simple-deployment/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: simple-deployment
 description: A Helm chart for a simple deployment, incl. service and ingress.
-version: 5.2.1
+version: 5.2.2

--- a/charts/simple-deployment/README.md
+++ b/charts/simple-deployment/README.md
@@ -53,8 +53,7 @@ deployment:
 
 ## Examples 3
 
-Below example enables a service and an ingress definition with the deployment. By default the ingress configuration will create a standard path rule. All traffic with a PathPrefix of "/" will be routed to the service.
-You can add more path rules with the `addtionalPaths` property. A TLS configuration will also be created.
+Below example enables a service and an ingress definition with the deployment using the standardized containerPort of 8080. By default the ingress configuration will create a standard path rule. All traffic with a PathPrefix of "/" will be routed to the service. You can add more path rules with the `addtionalPaths` property. A TLS configuration will also be created.
 
 ```yaml
 deployment:
@@ -62,7 +61,6 @@ deployment:
   container:
     image: my-image
     tag: v0.1.5
-    containerPort: 8080
 
 service:
   enable: true

--- a/charts/simple-deployment/README.md
+++ b/charts/simple-deployment/README.md
@@ -12,7 +12,7 @@ Here's a few bullet points on what it's capable of.
   - This is overwriteable with the boolean "exposure", or by setting your specific ingress with ingressClassName in your services' values file.
 - Public ingress by default in the GKE Cloud cluster.
 
-## Examples 1
+## Example 1
 
 First example is a very simple deployment of a pod.
 
@@ -24,7 +24,7 @@ deployment:
     tag: v0.1.5
 ```
 
-## Examples 2
+## Example 2
 
 Below example enables the Google Cloud SQL Proxy sidecar in the pod.
 
@@ -51,7 +51,7 @@ deployment:
     # secretKeyName: my-service-account-key
 ```
 
-## Examples 3
+## Example 3
 
 Below example enables a service and an ingress definition with the deployment using the standardized containerPort of 8080. By default the ingress configuration will create a standard path rule. All traffic with a PathPrefix of "/" will be routed to the service. You can add more path rules with the `addtionalPaths` property. A TLS configuration will also be created.
 
@@ -192,7 +192,7 @@ All possible cluster/env combinations are listed below along with the supported 
 |Gen 2|yes|yes|
 |Cloud|no|yes|
 
-# Exampel 6: External Secret Store
+## Example 6: External Secret Store
 Prequisite: Extrnal Secret Store must be enabled on the given project. If possible, please use the nuget package instead.
 
 In order to use the external secret store to create a kubernetes secret, the simple-deployment can be templated as follows.

--- a/charts/simple-deployment/templates/_helpers.tpl
+++ b/charts/simple-deployment/templates/_helpers.tpl
@@ -63,7 +63,7 @@ tags.datadoghq.com/version: {{ .Values.deployment.container.tag | quote }}
 {{- define "deployment.livenessProbe" -}}
 httpGet:
   path: {{ .livenessProbe.httpGet.path }}
-  port: {{ .containerPort }}
+  port: {{ .containerPort | default 8080 }}
 initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds | default 5 }}
 periodSeconds: {{ .livenessProbe.periodSeconds | default 10}}
 timeoutSeconds: {{ .livenessProbe.timeoutSeconds | default 1 }}
@@ -74,7 +74,7 @@ failureThreshold: {{ .livenessProbe.failureThreshold | default 3 }}
 {{- define "deployment.readinessProbe" -}}
 httpGet:
   path: {{ .readinessProbe.httpGet.path }}
-  port: {{ .containerPort }}
+  port: {{ .containerPort | default 8080 }}
 initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds | default 5 }}
 periodSeconds: {{ .readinessProbe.periodSeconds | default 10}}
 timeoutSeconds: {{ .readinessProbe.timeoutSeconds | default 1 }}
@@ -85,7 +85,7 @@ failureThreshold: {{ .readinessProbe.failureThreshold | default 3 }}
 {{- define "deployment.startupProbe" -}}
 httpGet:
   path: {{ .startupProbe.httpGet.path }}
-  port: {{ .containerPort }}
+  port: {{ .containerPort | default 8080 }}
 initialDelaySeconds: {{ .startupProbe.initialDelaySeconds | default 0 }}
 periodSeconds: {{ .startupProbe.periodSeconds | default 10}}
 timeoutSeconds: {{ .startupProbe.timeoutSeconds | default 1 }}

--- a/charts/simple-deployment/templates/ingress.yaml
+++ b/charts/simple-deployment/templates/ingress.yaml
@@ -42,7 +42,7 @@ spec:
           service:
             name: {{ include "deployment.name" $ }}
             port:
-              number: {{ .Values.deployment.container.containerPort | required "A container port is required on the container." }}
+              number: {{ .Values.deployment.container.containerPort | default "8080" }}
         {{- with .Values.ingress.addtionalPaths }}
         {{ toYaml . | nindent 6}}
         {{- end }}

--- a/charts/simple-deployment/templates/service.yaml
+++ b/charts/simple-deployment/templates/service.yaml
@@ -17,8 +17,8 @@ spec:
     app: {{ include "deployment.name" $ | quote }}
   ports:
   - protocol: TCP
-    port: {{ .Values.deployment.container.containerPort | required "A container port is required on the container." }}
-    targetPort: {{ .Values.deployment.container.containerPort | required "A container port is required on the container." }}
+    port: {{ .Values.deployment.container.containerPort | default "8080" }}
+    targetPort: {{ .Values.deployment.container.containerPort | default "8080" }}
     {{- if .Values.service.portName }}
     name: "{{ .Values.service.portName }}"
     {{- end}}

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -49,7 +49,7 @@ deployment:
     #args: ["with", "--params=yes"]
 
     # containerPort needs to be set if the container has to receive traffic.
-    containerPort: null
+    containerPort: 8080
     resources:
       requests:
         memory: 500Mi

--- a/charts/simple-deployment/values.yaml
+++ b/charts/simple-deployment/values.yaml
@@ -49,7 +49,7 @@ deployment:
     #args: ["with", "--params=yes"]
 
     # containerPort needs to be set if the container has to receive traffic.
-    containerPort: 8080
+    containerPort: null
     resources:
       requests:
         memory: 500Mi


### PR DESCRIPTION
To standardize what container port we are using, the default container port is now set to 8080.
- The Chart is still backwards compatible with overriding containerPort in the values files.